### PR TITLE
Added support for filtering unused named imports.

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,7 @@ export interface TransformerArgs<T> {
   map?: string | object;
   dianostics?: Array<unknown>;
   options?: T;
+  markup?: string;
 }
 
 export type Processed = SvelteProcessed & {

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -60,4 +60,5 @@ export interface Typescript {
   tsconfigDirectory?: string | boolean;
   transpileOnly?: boolean;
   reportDiagnostics?: boolean;
+  removeNonEmittingImports?: boolean;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -130,13 +130,13 @@ const TRANSFORMERS = {} as {
 export const runTransformer = async (
   name: string,
   options: TransformerOptions<any>,
-  { content, map, filename }: TransformerArgs<any>,
+  { content, map, filename, markup }: TransformerArgs<any>,
 ): Promise<ReturnType<Transformer<unknown>>> => {
   // remove any unnecessary indentation (useful for coffee, pug and sugarss)
   content = stripIndent(content);
 
   if (typeof options === 'function') {
-    return options({ content, map, filename });
+    return options({ content, map, filename, markup });
   }
 
   try {
@@ -150,6 +150,7 @@ export const runTransformer = async (
     return TRANSFORMERS[name]({
       content,
       filename,
+      markup,
       map,
       options: typeof options === 'boolean' ? null : options,
     });

--- a/test/fixtures/References.svelte
+++ b/test/fixtures/References.svelte
@@ -1,0 +1,10 @@
+<script lang="typescript">
+  import { Box, Circle, Triangle, Dot } from "./fixtures/shapes"
+
+  export let triangle: Dot;
+</script>
+
+<Box color="green">
+  <Circle color="orange">
+  </Circle>
+</Box>

--- a/test/fixtures/exports.ts
+++ b/test/fixtures/exports.ts
@@ -1,0 +1,6 @@
+export interface IFace {
+  readonly value: string;
+}
+
+export class ExportedClass {
+}

--- a/test/fixtures/shapes.ts
+++ b/test/fixtures/shapes.ts
@@ -1,0 +1,11 @@
+export class Box {
+}
+
+export class Circle {
+}
+
+export function Triangle() {
+}
+
+export interface Dot {
+}

--- a/test/transformers/babel.test.ts
+++ b/test/transformers/babel.test.ts
@@ -27,11 +27,11 @@ describe('transformer - babel', () => {
     });
     const preprocessed = await preprocess(template, opts);
     expect(preprocessed.code).toMatchInlineSnapshot(`
-      "<script>var _ref;
+      "<script>var _foo$b;
 
       var foo = {};
 
-      $: bar = (_ref = foo == null ? void 0 : foo.b) != null ? _ref : 120;</script>"
+      $: bar = (_foo$b = foo == null ? void 0 : foo.b) != null ? _foo$b : 120;</script>"
     `);
   });
 });


### PR DESCRIPTION
Uses the AST to check if named imports are used in the transpiled code. If not, filters out the named import. Another option could be to use the typechecker, but then it would break when transpileOnly was true.

Fixes #153.

This way non-emitting types will never be imported so we don't get the following error:

```[!] Error: '<Interface>' is not exported by <TypeScriptFile>.ts, imported by <SvelteFile>.svelte```



### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [x] Run the tests tests with `npm test` or `yarn test`
