### PR TITLE
feat: add the :global {} rule support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# [3.9.0](https://github.com/kaisermann/svelte-preprocess/compare/v3.7.4...v3.9.0) (2020-06-05)
+
+
+### Bug Fixes
+
+* 🐛 run globalRule only if postcss is installed ([6294750](https://github.com/kaisermann/svelte-preprocess/commit/62947507064271d1cec796d3e0a7801633b875a8))
+
+
+### Features
+
+* add implementation option for scss ([e4ca556](https://github.com/kaisermann/svelte-preprocess/commit/e4ca556821785e2b853f1668489912ebab21ee4b))
+* add the [@global](https://github.com/global) {} rule support ([46722ba](https://github.com/kaisermann/svelte-preprocess/commit/46722bac993308d8e4f1bb3d0b3086b802013d3d))
+* replace the [@global](https://github.com/global) for :global for CSS modules compliance ([3c6a574](https://github.com/kaisermann/svelte-preprocess/commit/3c6a574ac25ea84aea2d1d60e025680d404c30ff))
+
+
+
 # [3.8.0](https://github.com/kaisermann/svelte-preprocess/compare/v3.7.4...v3.8.0) (2020-06-05)
 
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ Current supported out-of-the-box preprocessors are `SCSS`, `Stylus`, `Less`, `Co
 <!-- Or -->
 
 <style type="text/stylus">
-  $color=reddivcolor: $color;
+  $color = red
+  div
+    color: $color
 </style>
 ```
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,30 @@ _Note<sup>1</sup>: needs postcss to be installed_
 
 _Note<sup>2</sup>: if you're using it as a standalone processor, it works best if added to the end of the processors array._
 
+_Note<sup>3</sup>: if you need to have some styles be scoped inside a global style tag, use `:local` in the same way you'd use `:global`._
+
+### Global rule
+
+Use a `@global` rule to only expose parts of the stylesheet:
+
+```html
+<style lang="scss">
+  .scoped-style {}
+
+  @global {
+    import 'global-stylesheet.css';
+
+    .global-style {
+      .global-child-style {}
+    }
+  }
+</style>
+```
+
+_Note<sup>1</sup>: needs postcss to be installed_
+
+_Note<sup>2</sup>: if you're using it as a standalone processor, it works best if added to the end of the processors array._
+
 ### Preprocessors
 
 Current supported out-of-the-box preprocessors are `SCSS`, `Stylus`, `Less`, `Coffeescript`, `TypeScript`, `Pug`, `PostCSS`, `Babel`.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ _Note: only for auto preprocessing_
 
 ### Global style
 
-Add a `global` attribute to your `style` tag and instead of scoping the css, all of its content will be interpreted as global style.
+Add a `global` attribute to your `style` tag and instead of scoping the CSS, all of its content will be interpreted as global style.
 
 ```html
 <style global>
@@ -89,7 +89,7 @@ Add a `global` attribute to your `style` tag and instead of scoping the css, all
 </style>
 ```
 
-_Note<sup>1</sup>: needs postcss to be installed_
+_Note<sup>1</sup>: needs PostCSS to be installed._
 
 _Note<sup>2</sup>: if you're using it as a standalone processor, it works best if added to the end of the processors array._
 
@@ -97,14 +97,14 @@ _Note<sup>3</sup>: if you need to have some styles be scoped inside a global sty
 
 ### Global rule
 
-Use a `@global` rule to only expose parts of the stylesheet:
+Use a `:global` rule to only expose parts of the stylesheet:
 
 ```html
 <style lang="scss">
   .scoped-style {}
 
-  @global {
-    import 'global-stylesheet.css';
+  :global {
+    @import 'global-stylesheet.scss';
 
     .global-style {
       .global-child-style {}
@@ -113,9 +113,13 @@ Use a `@global` rule to only expose parts of the stylesheet:
 </style>
 ```
 
-_Note<sup>1</sup>: needs postcss to be installed_
+Works best with nesting-enabled CSS preprocessors, but regular CSS selectors like `div :global .global1 .global2` are also supported.
+
+_Note<sup>1</sup>: needs PostCSS to be installed._
 
 _Note<sup>2</sup>: if you're using it as a standalone processor, it works best if added to the end of the processors array._
+
+_Note<sup>3</sup>: wrapping `@keyframes` inside `:global {}` blocks is not supported. Use the [`-global-` name prefix for global keyframes](https://svelte.dev/docs#style)._
 
 ### Preprocessors
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-preprocess",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/autoProcess.ts
+++ b/src/autoProcess.ts
@@ -27,10 +27,10 @@ interface Transformers {
   postcss?: TransformerOptions<Options.Postcss>;
   coffeescript?: TransformerOptions<Options.Coffeescript>;
   pug?: TransformerOptions<Options.Pug>;
-  globalStyle?: TransformerOptions<Options.Typescript>;
-  globalRule?: TransformerOptions<Options.Typescript>;
+  globalStyle?: TransformerOptions;
+  globalRule?: TransformerOptions;
   replace?: Options.Replace;
-  [languageName: string]: TransformerOptions<any>;
+  [languageName: string]: TransformerOptions;
 }
 
 type AutoPreprocessOptions = {
@@ -65,7 +65,7 @@ type AutoPreprocessOptions = {
     | Promise<string>
     | [string, string][]
     | string[]
-    | TransformerOptions<any>;
+    | TransformerOptions;
 };
 
 const SVELTE_MAJOR_VERSION = +version[0];

--- a/src/autoProcess.ts
+++ b/src/autoProcess.ts
@@ -27,6 +27,7 @@ interface Transformers {
   coffeescript?: TransformerOptions<Options.Coffeescript>;
   pug?: TransformerOptions<Options.Pug>;
   globalStyle?: TransformerOptions<Options.Typescript>;
+  globalRule?: TransformerOptions<Options.Typescript>;
   replace?: Options.Replace;
   [languageName: string]: TransformerOptions<any>;
 }
@@ -55,6 +56,7 @@ type AutoPreprocessOptions = {
   coffeescript?: TransformerOptions<Options.Coffeescript>;
   pug?: TransformerOptions<Options.Pug>;
   globalStyle?: TransformerOptions<Options.Typescript>;
+  globalRule?: TransformerOptions<Options.Typescript>;
   // workaround while we don't have this
   // https://github.com/microsoft/TypeScript/issues/17867
   [languageName: string]:
@@ -269,6 +271,15 @@ export function autoPreprocess(
         code = transformed.code;
         map = transformed.map;
       }
+
+      const transformed = await runTransformer('globalRule', null, {
+        content: code,
+        map,
+        filename,
+      });
+
+      code = transformed.code;
+      map = transformed.map;
 
       return { code, map, dependencies };
     },

--- a/src/autoProcess.ts
+++ b/src/autoProcess.ts
@@ -16,6 +16,7 @@ import {
   Options,
   Processed,
 } from './types';
+import { hasPostCssInstalled } from './modules/hasPostcssInstalled';
 
 interface Transformers {
   typescript?: TransformerOptions<Options.Typescript>;
@@ -261,25 +262,26 @@ export function autoPreprocess(
         dependencies = concat(dependencies, transformed.dependencies);
       }
 
-      if (attributes.global) {
-        const transformed = await runTransformer('globalStyle', null, {
+      if (await hasPostCssInstalled()) {
+        if (attributes.global) {
+          const transformed = await runTransformer('globalStyle', null, {
+            content: code,
+            map,
+            filename,
+          });
+
+          code = transformed.code;
+          map = transformed.map;
+        }
+
+        const transformed = await runTransformer('globalRule', null, {
           content: code,
           map,
           filename,
         });
-
         code = transformed.code;
         map = transformed.map;
       }
-
-      const transformed = await runTransformer('globalRule', null, {
-        content: code,
-        map,
-        filename,
-      });
-
-      code = transformed.code;
-      map = transformed.map;
 
       return { code, map, dependencies };
     },

--- a/src/modules/globalifySelector.ts
+++ b/src/modules/globalifySelector.ts
@@ -1,0 +1,16 @@
+export function globalifySelector(selector: string) {
+  return selector
+    .trim()
+    .split(' ')
+    .filter(Boolean)
+    .map((selectorPart) => {
+      if (selectorPart.startsWith(':local')) {
+        return selectorPart.replace(/:local\((.+?)\)/g, '$1');
+      }
+      if (selectorPart.startsWith(':global')) {
+        return selectorPart;
+      }
+      return `:global(${selectorPart})`;
+    })
+    .join(' ');
+}

--- a/src/modules/hasPostcssInstalled.ts
+++ b/src/modules/hasPostcssInstalled.ts
@@ -1,0 +1,17 @@
+let cachedResult: boolean;
+
+export async function hasPostCssInstalled() {
+  if (cachedResult != null) {
+    return cachedResult;
+  }
+
+  let result = false;
+  try {
+    await import('postcss');
+    result = true;
+  } catch (e) {
+    result = false;
+  }
+
+  return (cachedResult = result);
+}

--- a/src/modules/importAny.ts
+++ b/src/modules/importAny.ts
@@ -1,0 +1,11 @@
+export async function importAny(...modules: string[]) {
+  try {
+    const mod = await modules.reduce(
+      (acc, moduleName) => acc.catch(() => import(moduleName)),
+      Promise.reject(),
+    );
+    return mod;
+  } catch (e) {
+    throw new Error(`Cannot find any of modules: ${modules}`);
+  }
+}

--- a/src/processors/globalRule.ts
+++ b/src/processors/globalRule.ts
@@ -1,0 +1,13 @@
+import { PreprocessorGroup } from '../types';
+
+export default (): PreprocessorGroup => {
+  return {
+    async style({ content, filename }) {
+      const { default: transformer } = await import(
+        '../transformers/globalRule'
+      );
+
+      return transformer({ content, filename });
+    },
+  };
+};

--- a/src/transformers/globalRule.ts
+++ b/src/transformers/globalRule.ts
@@ -1,0 +1,28 @@
+import postcss from 'postcss';
+
+import { Transformer } from '../types';
+import { globalifyPlugin } from './globalStyle';
+
+const globalifyRulePlugin = (root: any) => {
+  root.walkAtRules(/^global$/, (atrule: any) => {
+    globalifyPlugin(atrule);
+    let after = atrule;
+
+    atrule.each(function (child: any) {
+      after.after(child);
+      after = child;
+    });
+
+    atrule.remove();
+  });
+};
+
+const transformer: Transformer<never> = async ({ content, filename }) => {
+  const { css, map: newMap } = await postcss()
+    .use(globalifyRulePlugin)
+    .process(content, { from: filename, map: true });
+
+  return { code: css, map: newMap };
+};
+
+export default transformer;

--- a/src/transformers/globalRule.ts
+++ b/src/transformers/globalRule.ts
@@ -1,19 +1,15 @@
 import postcss from 'postcss';
 
 import { Transformer } from '../types';
-import { globalifyPlugin } from './globalStyle';
+import { wrapSelectorInGlobal } from './globalStyle';
 
 const globalifyRulePlugin = (root: any) => {
-  root.walkAtRules(/^global$/, (atrule: any) => {
-    globalifyPlugin(atrule);
-    let after = atrule;
-
-    atrule.each(function (child: any) {
-      after.after(child);
-      after = child;
-    });
-
-    atrule.remove();
+  root.walkRules(/:global(?!\()/, (rule: any) => {
+    const [beginning, ...rest] = rule.selector.split(/:global(?!\()/);
+    rule.selector = (
+      beginning.trim() + ' '
+      + rest.filter((x: string) => !!x).map(wrapSelectorInGlobal).join(' ')
+    ).trim();
   });
 };
 

--- a/src/transformers/globalRule.ts
+++ b/src/transformers/globalRule.ts
@@ -1,15 +1,17 @@
 import postcss from 'postcss';
 
 import { Transformer } from '../types';
-import { wrapSelectorInGlobal } from './globalStyle';
+import { globalifySelector } from '../modules/globalifySelector';
+
+const selectorPattern = /:global(?!\()/;
 
 const globalifyRulePlugin = (root: any) => {
-  root.walkRules(/:global(?!\()/, (rule: any) => {
-    const [beginning, ...rest] = rule.selector.split(/:global(?!\()/);
-    rule.selector = (
-      beginning.trim() + ' '
-      + rest.filter((x: string) => !!x).map(wrapSelectorInGlobal).join(' ')
-    ).trim();
+  root.walkRules(selectorPattern, (rule: any) => {
+    const [beginning, ...rest] = rule.selector.split(selectorPattern);
+    rule.selector = [beginning, ...rest.map(globalifySelector)]
+      .map((str) => str.trim())
+      .join(' ')
+      .trim();
   });
 };
 

--- a/src/transformers/globalStyle.ts
+++ b/src/transformers/globalStyle.ts
@@ -2,7 +2,7 @@ import postcss from 'postcss';
 
 import { Transformer } from '../types';
 
-const globalifyPlugin = (root: any) => {
+export const globalifyPlugin = (root: any) => {
   root.walkAtRules(/keyframes$/, (atrule: any) => {
     if (!atrule.params.startsWith('-global-')) {
       atrule.params = '-global-' + atrule.params;

--- a/src/transformers/globalStyle.ts
+++ b/src/transformers/globalStyle.ts
@@ -1,27 +1,12 @@
 import postcss from 'postcss';
 
 import { Transformer } from '../types';
-
-export const wrapSelectorInGlobal = (selector: string) => {
-  return selector
-    .trim()
-    .split(' ')
-    .map((selectorPart) => {
-      if (selectorPart.startsWith(':local')) {
-        return selectorPart.replace(/:local\((.+?)\)/g, '$1');
-      }
-      if (selectorPart.startsWith(':global')) {
-        return selectorPart;
-      }
-      return `:global(${selectorPart})`;
-    })
-    .join(' ');
-};
+import { globalifySelector } from '../modules/globalifySelector';
 
 const globalifyPlugin = (root: any) => {
   root.walkAtRules(/keyframes$/, (atrule: any) => {
     if (!atrule.params.startsWith('-global-')) {
-      atrule.params = '-global-' + atrule.params;
+      atrule.params = `-global-${atrule.params}`;
     }
   });
 
@@ -30,7 +15,7 @@ const globalifyPlugin = (root: any) => {
       return;
     }
 
-    rule.selectors = rule.selectors.map(wrapSelectorInGlobal);
+    rule.selectors = rule.selectors.map(globalifySelector);
   });
 };
 

--- a/src/transformers/scss.ts
+++ b/src/transformers/scss.ts
@@ -1,7 +1,8 @@
 import { Result } from 'sass';
 
-import { importAny, getIncludePaths } from '../utils';
+import { getIncludePaths } from '../utils';
 import { Transformer, Processed, Options } from '../types';
+import { importAny } from '../modules/importAny';
 
 let sass: Options.Sass['implementation'];
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,7 +33,7 @@ export type Transformer<T> = (
   args: TransformerArgs<T>,
 ) => Processed | Promise<Processed>;
 
-export type TransformerOptions<T> =
+export type TransformerOptions<T = any> =
   | boolean
   | Record<string, any>
   | Transformer<T>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -159,15 +159,3 @@ export const runTransformer = async (
     );
   }
 };
-
-export const importAny = async (...modules: string[]) => {
-  try {
-    const mod = await modules.reduce(
-      (acc, moduleName) => acc.catch(() => import(moduleName)),
-      Promise.reject(),
-    );
-    return mod;
-  } catch (e) {
-    throw new Error(`Cannot find any of modules: ${modules}`);
-  }
-};

--- a/test/transformers/globalRule.test.ts
+++ b/test/transformers/globalRule.test.ts
@@ -6,6 +6,7 @@ describe('transformer - globalRule', () => {
     const template = `<style>:global div{color:red}:global .test{}</style>`;
     const opts = autoProcess();
     const preprocessed = await preprocess(template, opts);
+
     expect(preprocessed.toString()).toContain(
       `:global(div){color:red}:global(.test){}`,
     );
@@ -15,6 +16,7 @@ describe('transformer - globalRule', () => {
     const template = `<style>:global .test{}:global :global(.foo){}</style>`;
     const opts = autoProcess();
     const preprocessed = await preprocess(template, opts);
+
     expect(preprocessed.toString()).toContain(
       `:global(.test){}:global(.foo){}`,
     );
@@ -24,6 +26,7 @@ describe('transformer - globalRule', () => {
     const template = '<style>:global div .cls{}</style>';
     const opts = autoProcess();
     const preprocessed = await preprocess(template, opts);
+
     expect(preprocessed.toString()).toMatch(
       // either be :global(div .cls){}
       //        or :global(div) :global(.cls){}
@@ -32,13 +35,14 @@ describe('transformer - globalRule', () => {
   });
 
   it('wraps selector in :global(...) on multiple levels when in the middle', async () => {
-    const template = '<style>div :global span .cls{}</style>';
+    const template = '<style>div div :global span .cls{}</style>';
     const opts = autoProcess();
     const preprocessed = await preprocess(template, opts);
+
     expect(preprocessed.toString()).toMatch(
-      // either be div :global(span .cls) {}
-      //        or div :global(span) :global(.cls) {}
-      /div (:global\(span .cls\)\{\}|:global\(span\) :global\(\.cls\)\{\})/,
+      // either be div div :global(span .cls) {}
+      //        or div div :global(span) :global(.cls) {}
+      /div div (:global\(span .cls\)\{\}|:global\(span\) :global\(\.cls\)\{\})/,
     );
   });
 
@@ -46,6 +50,7 @@ describe('transformer - globalRule', () => {
     const template = '<style>span :global{}</style>';
     const opts = autoProcess();
     const preprocessed = await preprocess(template, opts);
+
     expect(preprocessed.toString()).toContain('span{}');
   });
 
@@ -53,6 +58,7 @@ describe('transformer - globalRule', () => {
     const template = '<style>div :global span :global .cls{}</style>';
     const opts = autoProcess();
     const preprocessed = await preprocess(template, opts);
+
     expect(preprocessed.toString()).toMatch(
       // either be div :global(span .cls) {}
       //        or div :global(span) :global(.cls) {}
@@ -64,6 +70,7 @@ describe('transformer - globalRule', () => {
     const template = '<style>div :global(span){}</style>';
     const opts = autoProcess();
     const preprocessed = await preprocess(template, opts);
+
     expect(preprocessed.toString()).toContain('div :global(span){}');
   });
 
@@ -71,6 +78,7 @@ describe('transformer - globalRule', () => {
     const template = '<style>div :global(span) :global .cls{}</style>';
     const opts = autoProcess();
     const preprocessed = await preprocess(template, opts);
+
     expect(preprocessed.toString()).toMatch(
       // either be div :global(span .cls) {}
       //        or div :global(span) :global(.cls) {}

--- a/test/transformers/globalRule.test.ts
+++ b/test/transformers/globalRule.test.ts
@@ -1,0 +1,42 @@
+import autoProcess from '../../src';
+import { preprocess } from '../utils';
+
+describe('transformer - globalRule', () => {
+  it('wraps selector in :global(...) modifier', async () => {
+    const template = `<style>@global{div{color:red}.test{}}</style>`;
+    const opts = autoProcess();
+    const preprocessed = await preprocess(template, opts);
+    expect(preprocessed.toString()).toContain(
+      `:global(div){color:red}:global(.test){}`,
+    );
+  });
+
+  it('wraps selector in :global(...) modifier only inside the rule', async () => {
+    const template = `<style>@global{div{color:red}}.test{}</style>`;
+    const opts = autoProcess();
+    const preprocessed = await preprocess(template, opts);
+    expect(preprocessed.toString()).toContain(
+      `:global(div){color:red}.test{}`,
+    );
+  });
+
+  it('wraps selector in :global(...) only if needed', async () => {
+    const template = `<style>@global{.test{}:global(.foo){}}</style>`;
+    const opts = autoProcess();
+    const preprocessed = await preprocess(template, opts);
+    expect(preprocessed.toString()).toContain(
+      `:global(.test){}:global(.foo){}`,
+    );
+  });
+
+  it("prefixes @keyframes names with '-global-' only if needed", async () => {
+    const template = `<style>
+      @global{@keyframes a {from{} to{}}@keyframes -global-b {from{} to{}}}
+    </style>`;
+    const opts = autoProcess();
+    const preprocessed = await preprocess(template, opts);
+    expect(preprocessed.toString()).toContain(
+      `@keyframes -global-a {from{} to{}}@keyframes -global-b {from{} to{}}`,
+    );
+  });
+});

--- a/test/transformers/globalRule.test.ts
+++ b/test/transformers/globalRule.test.ts
@@ -2,6 +2,13 @@ import autoProcess from '../../src';
 import { preprocess } from '../utils';
 
 describe('transformer - globalRule', () => {
+  it('does nothing if postcss is not installed', async () => {
+    const template = `<style>:global div{color:red}:global .test{}</style>`;
+    const opts = autoProcess();
+
+    expect(async () => await preprocess(template, opts)).not.toThrow();
+  });
+
   it('wraps selector in :global(...) modifier', async () => {
     const template = `<style>:global div{color:red}:global .test{}</style>`;
     const opts = autoProcess();

--- a/test/transformers/scss.test.ts
+++ b/test/transformers/scss.test.ts
@@ -30,7 +30,7 @@ const implementation: Options.Sass['implementation'] = {
 };
 
 describe('transformer - scss', () => {
-  it('should prepend scss content via `data` option property - via defaul async render', async () => {
+  it('should prepend scss content via `data` option property - via default async render', async () => {
     const template = `<style lang="scss"></style>`;
     const opts = getAutoPreprocess({
       scss: {

--- a/test/transformers/scss.test.ts
+++ b/test/transformers/scss.test.ts
@@ -7,7 +7,7 @@ import { Options } from '../../src/types';
 const implementation: Options.Sass['implementation'] = {
   render(options, callback) {
     callback(null, {
-      css: Buffer.from('Foo'),
+      css: Buffer.from('div#red{color:red}'),
       stats: {
         entry: 'data',
         start: 0,
@@ -18,7 +18,7 @@ const implementation: Options.Sass['implementation'] = {
     });
   },
   renderSync: () => ({
-    css: Buffer.from('Bar'),
+    css: Buffer.from('div#green{color:green}'),
     stats: {
       entry: 'data',
       start: 0,
@@ -58,7 +58,7 @@ describe('transformer - scss', () => {
       },
     });
     const preprocessed = await preprocess(template, opts);
-    expect(preprocessed.toString()).toContain('Foo');
+    expect(preprocessed.toString()).toContain('div#red{color:red}');
   });
 
   it('should prepend scss content via `data` option property - via renderSync', async () => {
@@ -95,6 +95,6 @@ describe('transformer - scss', () => {
       },
     });
     const preprocessed = await preprocess(template, opts);
-    expect(preprocessed.toString()).toContain('Bar');
+    expect(preprocessed.toString()).toContain('div#green{color:green}');
   });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'path';
 
-import { importAny, getIncludePaths } from '../src/utils';
+import { getIncludePaths } from '../src/utils';
+import { importAny } from '../src/modules/importAny';
 
 describe('utils - importAny', () => {
   it('should throw error when none exist', () => {


### PR DESCRIPTION
This implements the proposal discussed in Svelte RFCs: https://github.com/sveltejs/rfcs/pull/22#issuecomment-638139699

```html
<style>
  .scoped-style {}
  
  :global {
    import 'global-stylesheet';
  
    .global-style {}
  }
</style>
```

This would allow for fine control of what parts of the stylesheet should be made global.

### Tests

- [x] Run the tests tests with `npm test` or `yarn test`
