### PR TITLE
Do not break when :global is the only selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [3.9.4](https://github.com/kaisermann/svelte-preprocess/compare/v3.9.2...v3.9.4) (2020-06-06)
+
+
+### Bug Fixes
+
+* do not break when :global is the only selector ([f011b74](https://github.com/kaisermann/svelte-preprocess/commit/f011b74be18493de575920cea6b81a7287fc3c3a))
+* use the typescript transform to remove type imports ([3a15831](https://github.com/kaisermann/svelte-preprocess/commit/3a158318a77ca627bd1e365fb96dde1b6fefe1c0))
+
+
+
 ## [3.9.3](https://github.com/kaisermann/svelte-preprocess/compare/v3.9.2...v3.9.3) (2020-06-06)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-preprocess",
-  "version": "3.9.3",
+  "version": "3.9.4",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/transformers/globalRule.ts
+++ b/src/transformers/globalRule.ts
@@ -7,16 +7,24 @@ const selectorPattern = /:global(?!\()/;
 
 const globalifyRulePlugin: postcss.Transformer = (root) => {
   root.walkRules(selectorPattern, (rule) => {
-    const modifiedSelectors = rule.selectors.map((selector) => {
-      const [beginning, ...rest] = selector.split(selectorPattern);
+    const modifiedSelectors = rule.selectors
+      .filter((selector) => selector !== ':global')
+      .map((selector) => {
+        const [beginning, ...rest] = selector.split(selectorPattern);
 
-      if (rest.length === 0) return;
+        if (rest.length === 0) return beginning;
 
-      return [beginning, ...rest.map(globalifySelector)]
-        .map((str) => str.trim())
-        .join(' ')
-        .trim();
-    });
+        return [beginning, ...rest.map(globalifySelector)]
+          .map((str) => str.trim())
+          .join(' ')
+          .trim();
+      });
+
+    if (modifiedSelectors.length === 0) {
+      rule.remove();
+
+      return;
+    }
 
     rule.replaceWith(
       rule.clone({

--- a/test/transformers/globalRule.test.ts
+++ b/test/transformers/globalRule.test.ts
@@ -104,4 +104,15 @@ describe('transformer - globalRule', () => {
       /div (:global\(span .cls\)\{\}|:global\(span\) :global\(\.cls\)\{\})/,
     );
   });
+
+  it('remove rules with only :global its selector', async () => {
+    const template =
+      '<style>:global{/*comment*/}:global,div{/*comment*/}</style>';
+    const opts = autoProcess();
+    const preprocessed = await preprocess(template, opts);
+
+    expect(preprocessed.toString()).toContain(
+      '<style>div{/*comment*/}</style>',
+    );
+  });
 });


### PR DESCRIPTION
This is... embarrassing.

Apparently, for code like this:
```sass
:global {
  /* comment */
  .cls { color: red; }
}
```

Sass and Less will produce the following output:
```css
:global {
  /* comment */
}
:global .cls { 
  color: red; 
}
```

...which leaves us with comment-only rules that only consist of the `:global` selector, which gets lovingly transpiled into an empty string, producing things like `<style>{/* comment */}</style>`. This is to remedy that.

### Tests

- [x] Run the tests tests with `npm test` or `yarn test`
