### PR TITLE
Make the selector parsing smarter 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,521 +1,346 @@
 ## [3.9.5](https://github.com/kaisermann/svelte-preprocess/compare/v3.9.2...v3.9.5) (2020-06-06)
 
-
 ### Bug Fixes
 
-* add the comma into the list of combinators ([8386bf3](https://github.com/kaisermann/svelte-preprocess/commit/8386bf3adc0250bc3c3e5efaee7e21a1691cf336))
-* do not break when :global is the only selector ([3a7f0a2](https://github.com/kaisermann/svelte-preprocess/commit/3a7f0a21ceab5e2c033b1e90defb2260bf866a8f))
-* teach the globalifySelector to determine combinators ([1783c55](https://github.com/kaisermann/svelte-preprocess/commit/1783c550db0a8736c8fe27036f0cd1a8be3fa77a))
-* use the typescript transform to remove type imports ([3a15831](https://github.com/kaisermann/svelte-preprocess/commit/3a158318a77ca627bd1e365fb96dde1b6fefe1c0))
-
-
+- add the comma into the list of combinators ([8386bf3](https://github.com/kaisermann/svelte-preprocess/commit/8386bf3adc0250bc3c3e5efaee7e21a1691cf336))
+- teach the globalifySelector to determine combinators ([1783c55](https://github.com/kaisermann/svelte-preprocess/commit/1783c550db0a8736c8fe27036f0cd1a8be3fa77a))
 
 ## [3.9.4](https://github.com/kaisermann/svelte-preprocess/compare/v3.9.2...v3.9.4) (2020-06-06)
 
-
 ### Bug Fixes
 
-* do not break when :global is the only selector ([f011b74](https://github.com/kaisermann/svelte-preprocess/commit/f011b74be18493de575920cea6b81a7287fc3c3a))
-
-
+- do not break when :global is the only selector ([f011b74](https://github.com/kaisermann/svelte-preprocess/commit/f011b74be18493de575920cea6b81a7287fc3c3a))
 
 ## [3.9.3](https://github.com/kaisermann/svelte-preprocess/compare/v3.9.2...v3.9.3) (2020-06-06)
 
-
 ### Bug Fixes
 
-* use the typescript transform to remove type imports ([3a15831](https://github.com/kaisermann/svelte-preprocess/commit/3a158318a77ca627bd1e365fb96dde1b6fefe1c0))
+- use the typescript transform to remove type imports ([3a15831](https://github.com/kaisermann/svelte-preprocess/commit/3a158318a77ca627bd1e365fb96dde1b6fefe1c0))
 
 ## [3.9.2](https://github.com/kaisermann/svelte-preprocess/compare/v3.7.4...v3.9.2) (2020-06-06)
 
-
 ### Bug Fixes
 
-* 🐛 run globalRule only if postcss is installed ([3c22a20](https://github.com/kaisermann/svelte-preprocess/commit/3c22a203eb3fd565de783fdb6cb2e9faae270929))
-* 🐛 scss with empty content ([12c3af3](https://github.com/kaisermann/svelte-preprocess/commit/12c3af38aa191b15497418fa3bab8b1a241f21bb)), closes [#166](https://github.com/kaisermann/svelte-preprocess/issues/166)
-
+- 🐛 run globalRule only if postcss is installed ([3c22a20](https://github.com/kaisermann/svelte-preprocess/commit/3c22a203eb3fd565de783fdb6cb2e9faae270929))
+- 🐛 scss with empty content ([12c3af3](https://github.com/kaisermann/svelte-preprocess/commit/12c3af38aa191b15497418fa3bab8b1a241f21bb)), closes [#166](https://github.com/kaisermann/svelte-preprocess/issues/166)
 
 ### Features
 
-* 🎸 add globalStyle.sourceMap and globalRule.sourceMap opts ([2717c5b](https://github.com/kaisermann/svelte-preprocess/commit/2717c5b62eff78c512913adfb166439242715973))
-* add implementation option for scss ([e4ca556](https://github.com/kaisermann/svelte-preprocess/commit/e4ca556821785e2b853f1668489912ebab21ee4b))
-* add the [@global](https://github.com/global) {} rule support ([453c4be](https://github.com/kaisermann/svelte-preprocess/commit/453c4be2a2318d90cd86644d78e72404c72bd774))
-* replace the [@global](https://github.com/global) for :global for CSS modules compliance ([cca29fb](https://github.com/kaisermann/svelte-preprocess/commit/cca29fba848d3f75b6ba354a9909c1de021c7971))
-
-
+- 🎸 add globalStyle.sourceMap and globalRule.sourceMap opts ([2717c5b](https://github.com/kaisermann/svelte-preprocess/commit/2717c5b62eff78c512913adfb166439242715973))
+- add implementation option for scss ([e4ca556](https://github.com/kaisermann/svelte-preprocess/commit/e4ca556821785e2b853f1668489912ebab21ee4b))
+- add the [@global](https://github.com/global) {} rule support ([453c4be](https://github.com/kaisermann/svelte-preprocess/commit/453c4be2a2318d90cd86644d78e72404c72bd774))
+- replace the [@global](https://github.com/global) for :global for CSS modules compliance ([cca29fb](https://github.com/kaisermann/svelte-preprocess/commit/cca29fba848d3f75b6ba354a9909c1de021c7971))
 
 # [3.9.0](https://github.com/kaisermann/svelte-preprocess/compare/v3.7.4...v3.9.0) (2020-06-05)
 
-
 ### Bug Fixes
 
-* 🐛 run globalRule only if postcss is installed ([6294750](https://github.com/kaisermann/svelte-preprocess/commit/62947507064271d1cec796d3e0a7801633b875a8))
-
+- 🐛 run globalRule only if postcss is installed ([6294750](https://github.com/kaisermann/svelte-preprocess/commit/62947507064271d1cec796d3e0a7801633b875a8))
 
 ### Features
 
-* add implementation option for scss ([e4ca556](https://github.com/kaisermann/svelte-preprocess/commit/e4ca556821785e2b853f1668489912ebab21ee4b))
-* add the [@global](https://github.com/global) {} rule support ([46722ba](https://github.com/kaisermann/svelte-preprocess/commit/46722bac993308d8e4f1bb3d0b3086b802013d3d))
-* replace the [@global](https://github.com/global) for :global for CSS modules compliance ([3c6a574](https://github.com/kaisermann/svelte-preprocess/commit/3c6a574ac25ea84aea2d1d60e025680d404c30ff))
-
-
+- add implementation option for scss ([e4ca556](https://github.com/kaisermann/svelte-preprocess/commit/e4ca556821785e2b853f1668489912ebab21ee4b))
+- add the [@global](https://github.com/global) {} rule support ([46722ba](https://github.com/kaisermann/svelte-preprocess/commit/46722bac993308d8e4f1bb3d0b3086b802013d3d))
+- replace the [@global](https://github.com/global) for :global for CSS modules compliance ([3c6a574](https://github.com/kaisermann/svelte-preprocess/commit/3c6a574ac25ea84aea2d1d60e025680d404c30ff))
 
 # [3.8.0](https://github.com/kaisermann/svelte-preprocess/compare/v3.7.4...v3.8.0) (2020-06-05)
 
-
 ### Features
 
-* add implementation option for scss ([909e0c9](https://github.com/kaisermann/svelte-preprocess/commit/909e0c91be4a36fa3f9711d1ff4bc4f90fff64d3))
-
-
+- add implementation option for scss ([909e0c9](https://github.com/kaisermann/svelte-preprocess/commit/909e0c91be4a36fa3f9711d1ff4bc4f90fff64d3))
 
 ## [3.7.4](https://github.com/kaisermann/svelte-preprocess/compare/v3.7.3...v3.7.4) (2020-04-23)
 
-
-
 ## [3.7.3](https://github.com/kaisermann/svelte-preprocess/compare/v3.7.2...v3.7.3) (2020-04-22)
-
 
 ### Bug Fixes
 
-* 🐛 add preprocessors as optional peerDeps ([7f434df](https://github.com/kaisermann/svelte-preprocess/commit/7f434dfc78c8118afbe7142d8061a2d3df1a330c)), closes [#137](https://github.com/kaisermann/svelte-preprocess/issues/137)
-
-
+- 🐛 add preprocessors as optional peerDeps ([7f434df](https://github.com/kaisermann/svelte-preprocess/commit/7f434dfc78c8118afbe7142d8061a2d3df1a330c)), closes [#137](https://github.com/kaisermann/svelte-preprocess/issues/137)
 
 ## [3.7.2](https://github.com/kaisermann/svelte-preprocess/compare/v3.7.1...v3.7.2) (2020-04-21)
 
-
 ### Bug Fixes
 
-* 🐛 add `bare: true` to coffee compiler ([7d38bfd](https://github.com/kaisermann/svelte-preprocess/commit/7d38bfde34b6fafeca7e8df490348fd2004cdb1a)), closes [#134](https://github.com/kaisermann/svelte-preprocess/issues/134)
-
-
+- 🐛 add `bare: true` to coffee compiler ([7d38bfd](https://github.com/kaisermann/svelte-preprocess/commit/7d38bfde34b6fafeca7e8df490348fd2004cdb1a)), closes [#134](https://github.com/kaisermann/svelte-preprocess/issues/134)
 
 ## [3.7.1](https://github.com/kaisermann/svelte-preprocess/compare/v3.7.0...v3.7.1) (2020-03-29)
 
-
 ### Bug Fixes
 
-* 🐛 syntax and parser props from postcss config file ([74d4a89](https://github.com/kaisermann/svelte-preprocess/commit/74d4a8923faf619c3908dd63ba40626835303363)), closes [#127](https://github.com/kaisermann/svelte-preprocess/issues/127)
-
-
+- 🐛 syntax and parser props from postcss config file ([74d4a89](https://github.com/kaisermann/svelte-preprocess/commit/74d4a8923faf619c3908dd63ba40626835303363)), closes [#127](https://github.com/kaisermann/svelte-preprocess/issues/127)
 
 # [3.7.0](https://github.com/kaisermann/svelte-preprocess/compare/v3.6.0...v3.7.0) (2020-03-29)
 
-
 ### Bug Fixes
 
-* avoid reporting 'Cannot find name '{0}'. Did you mean '{1}'?' for reactive variables ([#126](https://github.com/kaisermann/svelte-preprocess/issues/126)) ([a267885](https://github.com/kaisermann/svelte-preprocess/commit/a267885e48a20c913368feafda153fa2389609e1))
-
+- avoid reporting 'Cannot find name '{0}'. Did you mean '{1}'?' for reactive variables ([#126](https://github.com/kaisermann/svelte-preprocess/issues/126)) ([a267885](https://github.com/kaisermann/svelte-preprocess/commit/a267885e48a20c913368feafda153fa2389609e1))
 
 ### Features
 
-* 🎸 add `replace` transformer ([06981f4](https://github.com/kaisermann/svelte-preprocess/commit/06981f410d0427bc75119cebebcb4b35c4b9a7dc))
-
-
+- 🎸 add `replace` transformer ([06981f4](https://github.com/kaisermann/svelte-preprocess/commit/06981f410d0427bc75119cebebcb4b35c4b9a7dc))
 
 # [3.6.0](https://github.com/kaisermann/svelte-preprocess/compare/v3.4.0...v3.6.0) (2020-03-26)
 
-
 ### Features
 
-* add an option to render scss synchronously via renderSync ([#123](https://github.com/kaisermann/svelte-preprocess/issues/123)) ([1c9285d](https://github.com/kaisermann/svelte-preprocess/commit/1c9285d508ec2fd0bea9b9f77a0940c6b3e00b89))
-
-
+- add an option to render scss synchronously via renderSync ([#123](https://github.com/kaisermann/svelte-preprocess/issues/123)) ([1c9285d](https://github.com/kaisermann/svelte-preprocess/commit/1c9285d508ec2fd0bea9b9f77a0940c6b3e00b89))
 
 # [3.5.0](https://github.com/kaisermann/svelte-preprocess/compare/v3.4.0...v3.5.0) (2020-03-13)
 
-
 ### Features
 
-* 🎸 add babel transformer ([adc47a1](https://github.com/kaisermann/svelte-preprocess/commit/adc47a1752c30a7630cf2567418d8475bb545bdb)), closes [#108](https://github.com/kaisermann/svelte-preprocess/issues/108)
-
-
+- 🎸 add babel transformer ([adc47a1](https://github.com/kaisermann/svelte-preprocess/commit/adc47a1752c30a7630cf2567418d8475bb545bdb)), closes [#108](https://github.com/kaisermann/svelte-preprocess/issues/108)
 
 # [3.4.0](https://github.com/kaisermann/svelte-preprocess/compare/v3.3.1...v3.4.0) (2020-02-02)
 
-
 ### Features
 
-* 🎸 watch included pug files ([a8855fb](https://github.com/kaisermann/svelte-preprocess/commit/a8855fb7a92affe27490c14f14341403568132d5))
-
-
+- 🎸 watch included pug files ([a8855fb](https://github.com/kaisermann/svelte-preprocess/commit/a8855fb7a92affe27490c14f14341403568132d5))
 
 ## [3.3.1](https://github.com/kaisermann/svelte-preprocess/compare/v3.2.6...v3.3.1) (2020-01-29)
 
-
 ### Bug Fixes
 
-* 🐛 postinstall script breaking on yarn v2 ([2f7f62b](https://github.com/kaisermann/svelte-preprocess/commit/2f7f62b5e0137bd621f1bff930289d0d97631cb9))
-
+- 🐛 postinstall script breaking on yarn v2 ([2f7f62b](https://github.com/kaisermann/svelte-preprocess/commit/2f7f62b5e0137bd621f1bff930289d0d97631cb9))
 
 ### Features
 
-* 🎸 support :local() pseudo-selector for global styles ([52277a8](https://github.com/kaisermann/svelte-preprocess/commit/52277a8af5492e1b0fc10cde16299a70da72cfdd))
-
-
+- 🎸 support :local() pseudo-selector for global styles ([52277a8](https://github.com/kaisermann/svelte-preprocess/commit/52277a8af5492e1b0fc10cde16299a70da72cfdd))
 
 # [3.3.0](https://github.com/kaisermann/svelte-preprocess/compare/v3.2.6...v3.3.0) (2019-12-19)
 
-
 ### Features
 
-* 🎸 support :local() pseudo-selector for global styles ([c9d98c2](https://github.com/kaisermann/svelte-preprocess/commit/c9d98c2da2bf62b628def6af2c2dd76027dd467c))
-
-
+- 🎸 support :local() pseudo-selector for global styles ([c9d98c2](https://github.com/kaisermann/svelte-preprocess/commit/c9d98c2da2bf62b628def6af2c2dd76027dd467c))
 
 ## [3.2.6](https://github.com/kaisermann/svelte-preprocess/compare/v3.2.5...v3.2.6) (2019-11-07)
 
-
 ### Bug Fixes
 
-* 🐛 concat passed inclusion paths with default ones ([aac8cd4](https://github.com/kaisermann/svelte-preprocess/commit/aac8cd47a1b8b5d8895027dad7d26f2dabea4c14))
-
-
+- 🐛 concat passed inclusion paths with default ones ([aac8cd4](https://github.com/kaisermann/svelte-preprocess/commit/aac8cd47a1b8b5d8895027dad7d26f2dabea4c14))
 
 ## [3.2.5](https://github.com/kaisermann/svelte-preprocess/compare/v3.2.4...v3.2.5) (2019-11-06)
 
-
 ### Bug Fixes
 
-* 🐛 empty scss content throwing error ([b4a4139](https://github.com/kaisermann/svelte-preprocess/commit/b4a4139a72068db5d32d27c5209f9e24dbe313dc))
-
-
+- 🐛 empty scss content throwing error ([b4a4139](https://github.com/kaisermann/svelte-preprocess/commit/b4a4139a72068db5d32d27c5209f9e24dbe313dc))
 
 ## [3.2.4](https://github.com/kaisermann/svelte-preprocess/compare/v3.2.3...v3.2.4) (2019-11-05)
 
-
 ### Bug Fixes
 
-* 🐛 rollback last release ([b4461b4](https://github.com/kaisermann/svelte-preprocess/commit/b4461b4431ce8d87ecd386f2fe40bb34775c3d8f))
-
-
+- 🐛 rollback last release ([b4461b4](https://github.com/kaisermann/svelte-preprocess/commit/b4461b4431ce8d87ecd386f2fe40bb34775c3d8f))
 
 ## [3.2.3](https://github.com/kaisermann/svelte-preprocess/compare/v3.2.2...v3.2.3) (2019-11-05)
 
-
 ### Bug Fixes
 
-* 🐛 add svelte component typings to ts type scope ([434d0b4](https://github.com/kaisermann/svelte-preprocess/commit/434d0b47bb639af826af9a3add474cca07aedaa7))
-
-
+- 🐛 add svelte component typings to ts type scope ([434d0b4](https://github.com/kaisermann/svelte-preprocess/commit/434d0b47bb639af826af9a3add474cca07aedaa7))
 
 ## [3.2.2](https://github.com/kaisermann/svelte-preprocess/compare/v3.2.1...v3.2.2) (2019-10-31)
 
-
 ### Bug Fixes
 
-* 🐛 support for self closing markup/template tag ([d109a89](https://github.com/kaisermann/svelte-preprocess/commit/d109a89656c050a28efdbc908d58958deb0ec08d))
-* 🐛 use ts import transformer when transpileOnly:true ([752fbde](https://github.com/kaisermann/svelte-preprocess/commit/752fbdef99e9cc13ac75c95a7dcc1fa0928f72b3)), closes [#91](https://github.com/kaisermann/svelte-preprocess/issues/91)
-
-
+- 🐛 support for self closing markup/template tag ([d109a89](https://github.com/kaisermann/svelte-preprocess/commit/d109a89656c050a28efdbc908d58958deb0ec08d))
+- 🐛 use ts import transformer when transpileOnly:true ([752fbde](https://github.com/kaisermann/svelte-preprocess/commit/752fbdef99e9cc13ac75c95a7dcc1fa0928f72b3)), closes [#91](https://github.com/kaisermann/svelte-preprocess/issues/91)
 
 ## [3.2.1](https://github.com/kaisermann/svelte-preprocess/compare/v3.1.3...v3.2.1) (2019-10-31)
 
-
 ### Bug Fixes
 
-* 🐛 prevent ts from removing unused imports ([cfe6dcb](https://github.com/kaisermann/svelte-preprocess/commit/cfe6dcbd23b7759f36bf7153222cab8e846cf8eb)), closes [#81](https://github.com/kaisermann/svelte-preprocess/issues/81)
-* 🐛 stylus imports on windows ([5bee6e0](https://github.com/kaisermann/svelte-preprocess/commit/5bee6e0a73e3f11814e9002f4dafef3b762de95b))
-* 🐛 transforming typescript without a tsconfig.json file ([7edb18a](https://github.com/kaisermann/svelte-preprocess/commit/7edb18aa27d44a216bdab72264116ca7cd5762ab))
-* 🐛 typescript imports on windows ([f6d6195](https://github.com/kaisermann/svelte-preprocess/commit/f6d6195fc4d60d03c61a6c548066288967cf0d5f))
-* don't try to include local files that doesn't exist ([52594eb](https://github.com/kaisermann/svelte-preprocess/commit/52594eb79e7533a442fd7063ef1e2e269269dbc3))
-
+- 🐛 prevent ts from removing unused imports ([cfe6dcb](https://github.com/kaisermann/svelte-preprocess/commit/cfe6dcbd23b7759f36bf7153222cab8e846cf8eb)), closes [#81](https://github.com/kaisermann/svelte-preprocess/issues/81)
+- 🐛 stylus imports on windows ([5bee6e0](https://github.com/kaisermann/svelte-preprocess/commit/5bee6e0a73e3f11814e9002f4dafef3b762de95b))
+- 🐛 transforming typescript without a tsconfig.json file ([7edb18a](https://github.com/kaisermann/svelte-preprocess/commit/7edb18aa27d44a216bdab72264116ca7cd5762ab))
+- 🐛 typescript imports on windows ([f6d6195](https://github.com/kaisermann/svelte-preprocess/commit/f6d6195fc4d60d03c61a6c548066288967cf0d5f))
+- don't try to include local files that doesn't exist ([52594eb](https://github.com/kaisermann/svelte-preprocess/commit/52594eb79e7533a442fd7063ef1e2e269269dbc3))
 
 ### Performance Improvements
 
-* rewrite in typescript ([#80](https://github.com/kaisermann/svelte-preprocess/issues/80)) ([f71f29c](https://github.com/kaisermann/svelte-preprocess/commit/f71f29c2fd051b9548845cfc188c3a245be6eb27))
-
-
+- rewrite in typescript ([#80](https://github.com/kaisermann/svelte-preprocess/issues/80)) ([f71f29c](https://github.com/kaisermann/svelte-preprocess/commit/f71f29c2fd051b9548845cfc188c3a245be6eb27))
 
 ## [3.1.3](https://github.com/kaisermann/svelte-preprocess/compare/v3.1.2...v3.1.3) (2019-10-23)
 
-
 ### Bug Fixes
 
-* 🐛 Try to only include files with local paths ([a167f6e](https://github.com/kaisermann/svelte-preprocess/commit/a167f6e4cc4802f86cc14fe38bbacf7e9db02729))
-
-
+- 🐛 Try to only include files with local paths ([a167f6e](https://github.com/kaisermann/svelte-preprocess/commit/a167f6e4cc4802f86cc14fe38bbacf7e9db02729))
 
 ## [3.1.2](https://github.com/kaisermann/svelte-preprocess/compare/v3.1.1...v3.1.2) (2019-09-25)
 
-
 ### Bug Fixes
 
-* 🐛 import less cjs instead of es6 ([bf8627f](https://github.com/kaisermann/svelte-preprocess/commit/bf8627f3f4bde0d598769a67de10194bbcf04701))
-
-
+- 🐛 import less cjs instead of es6 ([bf8627f](https://github.com/kaisermann/svelte-preprocess/commit/bf8627f3f4bde0d598769a67de10194bbcf04701))
 
 ## [3.1.1](https://github.com/kaisermann/svelte-preprocess/compare/v3.1.0...v3.1.1) (2019-09-10)
 
-
 ### Bug Fixes
 
-* 🐛 make [@keyframe](https://github.com/keyframe) at-rules global. ([#65](https://github.com/kaisermann/svelte-preprocess/issues/65)) ([40fb9be](https://github.com/kaisermann/svelte-preprocess/commit/40fb9be28e5737259754e9b1168efcaf25eef171))
-
-
+- 🐛 make [@keyframe](https://github.com/keyframe) at-rules global. ([#65](https://github.com/kaisermann/svelte-preprocess/issues/65)) ([40fb9be](https://github.com/kaisermann/svelte-preprocess/commit/40fb9be28e5737259754e9b1168efcaf25eef171))
 
 # [3.1.0](https://github.com/kaisermann/svelte-preprocess/compare/v3.0.2...v3.1.0) (2019-09-03)
 
-
 ### Features
 
-* 🎸 add "markupTagName" option ([746d2ab](https://github.com/kaisermann/svelte-preprocess/commit/746d2abbaaf072d3fac29cc2d2c0f61fa28d58e8))
-
-
+- 🎸 add "markupTagName" option ([746d2ab](https://github.com/kaisermann/svelte-preprocess/commit/746d2abbaaf072d3fac29cc2d2c0f61fa28d58e8))
 
 ## [3.0.2](https://github.com/kaisermann/svelte-preprocess/compare/v3.0.1...v3.0.2) (2019-08-29)
 
-
 ### Bug Fixes
 
-* 🐛 inverted conditionals on typescript transformer ([a6937f0](https://github.com/kaisermann/svelte-preprocess/commit/a6937f0d9895ceca69bbb335d918bbe69d16c2a4))
-
-
+- 🐛 inverted conditionals on typescript transformer ([a6937f0](https://github.com/kaisermann/svelte-preprocess/commit/a6937f0d9895ceca69bbb335d918bbe69d16c2a4))
 
 ## [3.0.1](https://github.com/kaisermann/svelte-preprocess/compare/v3.0.0...v3.0.1) (2019-08-29)
 
-
 ### Bug Fixes
 
-* 🐛 wrong typescript diagnostic filtering ([2630a44](https://github.com/kaisermann/svelte-preprocess/commit/2630a44f4d6036a87f7120b5482b2c236cccd9a0)), closes [#49](https://github.com/kaisermann/svelte-preprocess/issues/49)
-
-
+- 🐛 wrong typescript diagnostic filtering ([2630a44](https://github.com/kaisermann/svelte-preprocess/commit/2630a44f4d6036a87f7120b5482b2c236cccd9a0)), closes [#49](https://github.com/kaisermann/svelte-preprocess/issues/49)
 
 # [3.0.0](https://github.com/kaisermann/svelte-preprocess/compare/v2.16.0...v3.0.0) (2019-08-28)
 
-
 ### Performance Improvements
 
-* ⚡️ make postcss-load-config optional for better pkg size ([7ab9c72](https://github.com/kaisermann/svelte-preprocess/commit/7ab9c72797a3b702f2f3dd9280402b84057398be))
-
+- ⚡️ make postcss-load-config optional for better pkg size ([7ab9c72](https://github.com/kaisermann/svelte-preprocess/commit/7ab9c72797a3b702f2f3dd9280402b84057398be))
 
 ### BREAKING CHANGES
 
-* To load PostCSS config automatically from a file, now it's needed to
-manually install "postcss-load-config".
-
-
+- To load PostCSS config automatically from a file, now it's needed to
+  manually install "postcss-load-config".
 
 # [2.16.0](https://github.com/kaisermann/svelte-preprocess/compare/v2.15.2...v2.16.0) (2019-08-28)
 
-
 ### Features
 
-* 🎸 add "transpileOnly" option to skip type check ([3e46741](https://github.com/kaisermann/svelte-preprocess/commit/3e46741d917b8be5dcd331f5672bcd0c7ff75090)), closes [#54](https://github.com/kaisermann/svelte-preprocess/issues/54)
-
-
+- 🎸 add "transpileOnly" option to skip type check ([3e46741](https://github.com/kaisermann/svelte-preprocess/commit/3e46741d917b8be5dcd331f5672bcd0c7ff75090)), closes [#54](https://github.com/kaisermann/svelte-preprocess/issues/54)
 
 ## [2.15.2](https://github.com/kaisermann/svelte-preprocess/compare/v2.15.0...v2.15.2) (2019-08-28)
 
-
 ### Bug Fixes
 
-* 🐛 make pug mixins work with space AND tabs ([81b0154](https://github.com/kaisermann/svelte-preprocess/commit/81b0154a2e90375a9f5793c8d7fd32698ef9f432))
-* rename typescript configuration option to honor the readme docs ([67f2137](https://github.com/kaisermann/svelte-preprocess/commit/67f2137f9b6c11f3d2f4508d6dab2699e0d0b823))
-
-
+- 🐛 make pug mixins work with space AND tabs ([81b0154](https://github.com/kaisermann/svelte-preprocess/commit/81b0154a2e90375a9f5793c8d7fd32698ef9f432))
+- rename typescript configuration option to honor the readme docs ([67f2137](https://github.com/kaisermann/svelte-preprocess/commit/67f2137f9b6c11f3d2f4508d6dab2699e0d0b823))
 
 # [2.15.0](https://github.com/kaisermann/svelte-preprocess/compare/v2.14.4...v2.15.0) (2019-07-20)
 
-
 ### Features
 
-* 🎸 add external src support for stand-alone processors ([974ab5a](https://github.com/kaisermann/svelte-preprocess/commit/974ab5a05c37e32da1abe0e59fb777d07efb0b3c))
-
-
+- 🎸 add external src support for stand-alone processors ([974ab5a](https://github.com/kaisermann/svelte-preprocess/commit/974ab5a05c37e32da1abe0e59fb777d07efb0b3c))
 
 ## [2.14.4](https://github.com/kaisermann/svelte-preprocess/compare/v2.14.3...v2.14.4) (2019-07-03)
 
-
 ### Features
 
-* 🎸 allow to watch stylus dependencies ([8aa3dfc](https://github.com/kaisermann/svelte-preprocess/commit/8aa3dfcd73730688c3a4d555ebf5a56cf36c669f))
-
-
+- 🎸 allow to watch stylus dependencies ([8aa3dfc](https://github.com/kaisermann/svelte-preprocess/commit/8aa3dfcd73730688c3a4d555ebf5a56cf36c669f))
 
 ## [2.14.3](https://github.com/kaisermann/svelte-preprocess/compare/v2.14.2...v2.14.3) (2019-07-01)
 
-
 ### Bug Fixes
 
-* 🐛 pass less [@imports](https://github.com/imports) as dependencies to svelte ([55e9d28](https://github.com/kaisermann/svelte-preprocess/commit/55e9d28fd03a2a1bf07c4d1b9ec3517fe2ce0cb3))
-
-
+- 🐛 pass less [@imports](https://github.com/imports) as dependencies to svelte ([55e9d28](https://github.com/kaisermann/svelte-preprocess/commit/55e9d28fd03a2a1bf07c4d1b9ec3517fe2ce0cb3))
 
 ## [2.14.2](https://github.com/kaisermann/svelte-preprocess/compare/v2.14.1...v2.14.2) (2019-06-29)
 
-
 ### Bug Fixes
 
-* pug mixin elseif ([#45](https://github.com/kaisermann/svelte-preprocess/issues/45)) ([98ad9ca](https://github.com/kaisermann/svelte-preprocess/commit/98ad9ca996c70da25666e4f1e9286d4dfd15fb36))
-
-
+- pug mixin elseif ([#45](https://github.com/kaisermann/svelte-preprocess/issues/45)) ([98ad9ca](https://github.com/kaisermann/svelte-preprocess/commit/98ad9ca996c70da25666e4f1e9286d4dfd15fb36))
 
 ## [2.14.1](https://github.com/kaisermann/svelte-preprocess/compare/v2.14.0...v2.14.1) (2019-06-28)
 
-
 ### Bug Fixes
 
-* 🐛 transformer imported dependencies being overwritten ([423c17a](https://github.com/kaisermann/svelte-preprocess/commit/423c17a23283bca40ac0d8adf192ec1037196a12))
-
-
+- 🐛 transformer imported dependencies being overwritten ([423c17a](https://github.com/kaisermann/svelte-preprocess/commit/423c17a23283bca40ac0d8adf192ec1037196a12))
 
 # [2.14.0](https://github.com/kaisermann/svelte-preprocess/compare/v2.13.1...v2.14.0) (2019-06-22)
 
-
-
 ## [2.13.1](https://github.com/kaisermann/svelte-preprocess/compare/v2.13.0...v2.13.1) (2019-06-21)
-
-
 
 # [2.13.0](https://github.com/kaisermann/svelte-preprocess/compare/v2.12.0...v2.13.0) (2019-06-21)
 
-
-
 # [2.12.0](https://github.com/kaisermann/svelte-preprocess/compare/v2.7.1...v2.12.0) (2019-06-03)
-
 
 ### Bug Fixes
 
-* 🐛 template preprocessing running on the whole file ([e37da9d](https://github.com/kaisermann/svelte-preprocess/commit/e37da9d5f8f5fde5077e02add17be039db729e32))
-
+- 🐛 template preprocessing running on the whole file ([e37da9d](https://github.com/kaisermann/svelte-preprocess/commit/e37da9d5f8f5fde5077e02add17be039db729e32))
 
 ### Features
 
-* 🎸 add support for typescript type checking ([#37](https://github.com/kaisermann/svelte-preprocess/issues/37)) ([e6dd744](https://github.com/kaisermann/svelte-preprocess/commit/e6dd7441db64906f79d7105723e23a8ef949e2d5))
-* 🎸 add svelte pug mixins ([#38](https://github.com/kaisermann/svelte-preprocess/issues/38)) ([543ab75](https://github.com/kaisermann/svelte-preprocess/commit/543ab7557bd8e8172ea52e89355101d3c88a38ba))
-* 🎸 add typescript preprocessor ([c195aa1](https://github.com/kaisermann/svelte-preprocess/commit/c195aa183b60899603d72743432de501b23f6087))
-* prepend scss with data property ([#36](https://github.com/kaisermann/svelte-preprocess/issues/36)) ([dfa2b2a](https://github.com/kaisermann/svelte-preprocess/commit/dfa2b2a24124c94c3d3af6e63eff8963489f7caa))
-
-
+- 🎸 add support for typescript type checking ([#37](https://github.com/kaisermann/svelte-preprocess/issues/37)) ([e6dd744](https://github.com/kaisermann/svelte-preprocess/commit/e6dd7441db64906f79d7105723e23a8ef949e2d5))
+- 🎸 add svelte pug mixins ([#38](https://github.com/kaisermann/svelte-preprocess/issues/38)) ([543ab75](https://github.com/kaisermann/svelte-preprocess/commit/543ab7557bd8e8172ea52e89355101d3c88a38ba))
+- 🎸 add typescript preprocessor ([c195aa1](https://github.com/kaisermann/svelte-preprocess/commit/c195aa183b60899603d72743432de501b23f6087))
+- prepend scss with data property ([#36](https://github.com/kaisermann/svelte-preprocess/issues/36)) ([dfa2b2a](https://github.com/kaisermann/svelte-preprocess/commit/dfa2b2a24124c94c3d3af6e63eff8963489f7caa))
 
 ## [2.7.1](https://github.com/kaisermann/svelte-preprocess/compare/v2.6.5...v2.7.1) (2019-05-08)
 
-
 ### Bug Fixes
 
-* 🐛 cut 90% of downloaded package size ([882a4dd](https://github.com/kaisermann/svelte-preprocess/commit/882a4dd5c185c5063ceb27884877958d4178c0e8))
-
+- 🐛 cut 90% of downloaded package size ([882a4dd](https://github.com/kaisermann/svelte-preprocess/commit/882a4dd5c185c5063ceb27884877958d4178c0e8))
 
 ### Features
 
-* 🎸 watch internal files imported with postcss-import ([5b14624](https://github.com/kaisermann/svelte-preprocess/commit/5b14624ac04a9812e680b252b8f6d69c97c30188))
-
-
+- 🎸 watch internal files imported with postcss-import ([5b14624](https://github.com/kaisermann/svelte-preprocess/commit/5b14624ac04a9812e680b252b8f6d69c97c30188))
 
 ## [2.6.5](https://github.com/kaisermann/svelte-preprocess/compare/v2.6.4...v2.6.5) (2019-05-05)
 
-
 ### Bug Fixes
 
-* 🐛 stand-alone processors not exported ([ced0fd1](https://github.com/kaisermann/svelte-preprocess/commit/ced0fd1dfc34e13aefa13ba9d31efd81255e348d))
-
-
+- 🐛 stand-alone processors not exported ([ced0fd1](https://github.com/kaisermann/svelte-preprocess/commit/ced0fd1dfc34e13aefa13ba9d31efd81255e348d))
 
 ## [2.6.4](https://github.com/kaisermann/svelte-preprocess/compare/v2.6.3...v2.6.4) (2019-05-05)
 
-
 ### Bug Fixes
 
-* 🐛 less and stylus stand-alone processor ([85827bb](https://github.com/kaisermann/svelte-preprocess/commit/85827bbd53340b39b99b706f03c926d3b01bbad6))
-
-
+- 🐛 less and stylus stand-alone processor ([85827bb](https://github.com/kaisermann/svelte-preprocess/commit/85827bbd53340b39b99b706f03c926d3b01bbad6))
 
 ## [2.6.3](https://github.com/kaisermann/svelte-preprocess/compare/v2.6.2...v2.6.3) (2019-05-01)
 
-
 ### Features
 
-* support dart-sass ([e56f8b2](https://github.com/kaisermann/svelte-preprocess/commit/e56f8b24c8f93db82ef9bb0f17dd658aaf000126))
-
-
+- support dart-sass ([e56f8b2](https://github.com/kaisermann/svelte-preprocess/commit/e56f8b24c8f93db82ef9bb0f17dd658aaf000126))
 
 ## [2.6.2](https://github.com/kaisermann/svelte-preprocess/compare/v2.5.2...v2.6.2) (2019-04-11)
 
-
 ### Bug Fixes
 
-* 🐛 standalone processors breaking everything :) ([ce11323](https://github.com/kaisermann/svelte-preprocess/commit/ce113236f0ca2fe5876b75d7c9935f664634cae0))
-
+- 🐛 standalone processors breaking everything :) ([ce11323](https://github.com/kaisermann/svelte-preprocess/commit/ce113236f0ca2fe5876b75d7c9935f664634cae0))
 
 ### Features
 
-* 🎸 add stand-alone processors ([f19c90a](https://github.com/kaisermann/svelte-preprocess/commit/f19c90a1ed2838a8712b0c95dccbd8b005d8f9c0))
-
-
+- 🎸 add stand-alone processors ([f19c90a](https://github.com/kaisermann/svelte-preprocess/commit/f19c90a1ed2838a8712b0c95dccbd8b005d8f9c0))
 
 ## [2.5.2](https://github.com/kaisermann/svelte-preprocess/compare/v2.5.1...v2.5.2) (2019-04-10)
 
-
 ### Features
 
-* 🎸 support async onBefore() ([a6af2a2](https://github.com/kaisermann/svelte-preprocess/commit/a6af2a276cfc728ed60631eba5072b83cb035991))
-
-
+- 🎸 support async onBefore() ([a6af2a2](https://github.com/kaisermann/svelte-preprocess/commit/a6af2a276cfc728ed60631eba5072b83cb035991))
 
 ## [2.5.1](https://github.com/kaisermann/svelte-preprocess/compare/v2.4.2...v2.5.1) (2019-04-02)
 
-
 ### Bug Fixes
 
-* 🐛 custom transformer not working with external src files ([cc037c3](https://github.com/kaisermann/svelte-preprocess/commit/cc037c3cdae72f16c1f977986a1434006dc3fe96))
-
-
+- 🐛 custom transformer not working with external src files ([cc037c3](https://github.com/kaisermann/svelte-preprocess/commit/cc037c3cdae72f16c1f977986a1434006dc3fe96))
 
 ## [2.4.2](https://github.com/kaisermann/svelte-preprocess/compare/v2.4.1...v2.4.2) (2018-11-03)
 
-
-
 ## [2.4.1](https://github.com/kaisermann/svelte-preprocess/compare/v2.4.0...v2.4.1) (2018-11-02)
-
-
 
 # [2.4.0](https://github.com/kaisermann/svelte-preprocess/compare/v2.3.1...v2.4.0) (2018-11-01)
 
-
-
 ## [2.3.1](https://github.com/kaisermann/svelte-preprocess/compare/v2.2.2...v2.3.1) (2018-09-01)
-
-
 
 ## [2.2.2](https://github.com/kaisermann/svelte-preprocess/compare/v2.2.1...v2.2.2) (2018-07-18)
 
-
-
 ## [2.2.1](https://github.com/kaisermann/svelte-preprocess/compare/v2.2.0...v2.2.1) (2018-07-18)
-
-
 
 # [2.2.0](https://github.com/kaisermann/svelte-preprocess/compare/v2.1.4...v2.2.0) (2018-07-18)
 
-
-
 ## [2.1.3](https://github.com/kaisermann/svelte-preprocess/compare/v2.1.0...v2.1.3) (2018-06-21)
-
-
 
 # [2.1.0](https://github.com/kaisermann/svelte-preprocess/compare/v2.0.5...v2.1.0) (2018-06-20)
 
-
-
 ## [2.0.5](https://github.com/kaisermann/svelte-preprocess/compare/v2.0.4...v2.0.5) (2018-05-17)
-
-
 
 ## [2.0.4](https://github.com/kaisermann/svelte-preprocess/compare/v2.0.3...v2.0.4) (2018-05-17)
 
-
-
 ## [2.0.2](https://github.com/kaisermann/svelte-preprocess/compare/v2.0.1...v2.0.2) (2018-05-15)
-
-
 
 ## [2.0.1](https://github.com/kaisermann/svelte-preprocess/compare/1.1.2...v2.0.1) (2018-05-15)
 
-
-
 ## 1.1.2 (2018-05-14)
-
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [3.9.5](https://github.com/kaisermann/svelte-preprocess/compare/v3.9.2...v3.9.5) (2020-06-06)
+
+
+### Bug Fixes
+
+* add the comma into the list of combinators ([8386bf3](https://github.com/kaisermann/svelte-preprocess/commit/8386bf3adc0250bc3c3e5efaee7e21a1691cf336))
+* do not break when :global is the only selector ([3a7f0a2](https://github.com/kaisermann/svelte-preprocess/commit/3a7f0a21ceab5e2c033b1e90defb2260bf866a8f))
+* teach the globalifySelector to determine combinators ([1783c55](https://github.com/kaisermann/svelte-preprocess/commit/1783c550db0a8736c8fe27036f0cd1a8be3fa77a))
+* use the typescript transform to remove type imports ([3a15831](https://github.com/kaisermann/svelte-preprocess/commit/3a158318a77ca627bd1e365fb96dde1b6fefe1c0))
+
+
+
 ## [3.9.4](https://github.com/kaisermann/svelte-preprocess/compare/v3.9.2...v3.9.4) (2020-06-06)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-preprocess",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/modules/globalifySelector.ts
+++ b/src/modules/globalifySelector.ts
@@ -1,4 +1,4 @@
-const combinatorPattern = /(\s*[ >+~]\s*)(?![^[]+\])/g;
+const combinatorPattern = /(\s*[ >+~,]\s*)(?![^[]+\])/g;
 
 export function globalifySelector(selector: string) {
   return selector

--- a/src/modules/globalifySelector.ts
+++ b/src/modules/globalifySelector.ts
@@ -1,9 +1,19 @@
+const combinatorPattern = /(\s*[ >+~]\s*)(?![^[]+\])/g;
+
 export function globalifySelector(selector: string) {
   return selector
     .trim()
-    .split(' ')
-    .filter(Boolean)
-    .map((selectorPart) => {
+    .split(combinatorPattern)
+    .map((selectorPart: string, index: number) => {
+      // if this is the separator
+      if (index % 2 !== 0) {
+        return selectorPart;
+      }
+
+      if (selectorPart === '') {
+        return selectorPart;
+      }
+
       if (selectorPart.startsWith(':local')) {
         return selectorPart.replace(/:local\((.+?)\)/g, '$1');
       }
@@ -13,5 +23,5 @@ export function globalifySelector(selector: string) {
 
       return `:global(${selectorPart})`;
     })
-    .join(' ');
+    .join('');
 }

--- a/test/modules.test.ts
+++ b/test/modules.test.ts
@@ -64,10 +64,8 @@ describe('globalifySelector', () => {
     const selector1 = 'div > span';
     const selector2 = 'div, span';
 
-    expect(globalifySelector(selector1)).toMatch(
-      // either be :global(div > span)
-      //        or :global(div) > :global(span)
-      /(:global\(div> span\)|:global\(div\) > :global\(span\))/,
+    expect(globalifySelector(selector1)).toEqual(
+      ':global(div) > :global(span)',
     );
     expect(globalifySelector(selector2)).toEqual(':global(div), :global(span)');
   });

--- a/test/modules.test.ts
+++ b/test/modules.test.ts
@@ -2,6 +2,7 @@ import { resolve } from 'path';
 
 import { importAny } from '../src/modules/importAny';
 import { getIncludePaths } from '../src/modules/getIncludePaths';
+import { globalifySelector } from '../src/modules/globalifySelector';
 
 describe('importAny', () => {
   it('should throw error when none exist', () => {
@@ -47,5 +48,25 @@ describe('getIncludePaths', () => {
     ]);
 
     expect(paths).toEqual(['src', 'node_modules', process.cwd(), dummyDir]);
+  });
+});
+
+describe('globalifySelector', () => {
+  it('correctly treats CSS selectors with legal spaces', async () => {
+    const selector = '[attr="with spaces"]';
+
+    expect(globalifySelector(selector)).toEqual(
+      ':global([attr="with spaces"])',
+    );
+  });
+
+  it('correctly treats CSS combinators', async () => {
+    const selector = 'div > span';
+
+    expect(globalifySelector(selector)).toMatch(
+      // either be :global(div > span)
+      //        or :global(div) > :global(span)
+      /(:global\(div> span\)|:global\(div\) > :global\(span\))/,
+    );
   });
 });

--- a/test/modules.test.ts
+++ b/test/modules.test.ts
@@ -61,12 +61,14 @@ describe('globalifySelector', () => {
   });
 
   it('correctly treats CSS combinators', async () => {
-    const selector = 'div > span';
+    const selector1 = 'div > span';
+    const selector2 = 'div, span';
 
-    expect(globalifySelector(selector)).toMatch(
+    expect(globalifySelector(selector1)).toMatch(
       // either be :global(div > span)
       //        or :global(div) > :global(span)
       /(:global\(div> span\)|:global\(div\) > :global\(span\))/,
     );
+    expect(globalifySelector(selector2)).toEqual(':global(div), :global(span)');
   });
 });

--- a/test/transformers/globalRule.test.ts
+++ b/test/transformers/globalRule.test.ts
@@ -105,7 +105,7 @@ describe('transformer - globalRule', () => {
     );
   });
 
-  it('remove rules with only :global its selector', async () => {
+  it('removes rules with only :global as its selector', async () => {
     const template =
       '<style>:global{/*comment*/}:global,div{/*comment*/}</style>';
     const opts = autoProcess();


### PR DESCRIPTION
Previously, the selectors were split by a single literal space, which is rather naive. This PR allows for all kinds of whitespace, combinators like `>`, `+`, `~`, as well as spaces that aren't combinators (`[attr="with spaces"]`)

### Tests

- [x] Run the tests tests with `npm test` or `yarn test`
