### PR TITLE
Fix the quotes in the release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "format": "prettier --loglevel silent --write \"{src,test}/**/*.ts\" && eslint --fix \"{src,test}/**/*.ts\"",
     "postinstall": "echo \"[svelte-preprocess] Don't forget to install the preprocessors packages that will be used: node-sass/sass, stylus, less, postcss & postcss-load-config, coffeescript, pug, etc...\"",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s -r 1 && git add CHANGELOG.md",
-    "tag": "git tag -a v$npm_package_version -m 'Release v$npm_package_version'",
+    "tag": "git tag -a v$npm_package_version -m \"Release v$npm_package_version\"",
     "release": "npm run version && yarn && git add package.json yarn.lock && git commit -m \"chore(release): v$npm_package_version :tada:\"",
     "minify": "babel-minify dist -d dist",
     "prepublishOnly": "npm run test && npm run build && npm run minify && npm run release && npm run tag"


### PR DESCRIPTION
In Bash, single quotes prevent variable substitution, which results in all of the releases having `Release v$npm_package_version` as their tag message. This is to fix that.

Also, it would be nice to incorporate the CHANGELOG.md into those messages as well, but I don't know how would one do that.