### PR TITLE
fix: 🐛 prevent globalify to wrongly split escaped selectors

### DIFF
--- a/src/modules/globalifySelector.ts
+++ b/src/modules/globalifySelector.ts
@@ -1,9 +1,14 @@
-const combinatorPattern = /(\s*[ >+~,]\s*)(?![^[]+\])/g;
+/*
+ * Split a selector string (ex: div > foo ~ .potato) by
+ * separators: space, >, +, ~ and comma (maybe not needed)
+ * We use a negative lookbehind assertion to prevent matching
+ * escaped combinators like `\~`.
+ */
+const combinatorPattern = /(?<!\\)(?:\\\\)*([ >+~,]\s*)(?![^[]+\])/g;
 
 export function globalifySelector(selector: string) {
-  return selector
-    .trim()
-    .split(combinatorPattern)
+  const parts = selector.trim().split(combinatorPattern);
+  const modifiedSelector = parts
     .map((selectorPart: string, index: number) => {
       // if this is the separator
       if (index % 2 !== 0) {
@@ -25,4 +30,6 @@ export function globalifySelector(selector: string) {
       return `:global(${selectorPart})`;
     })
     .join('');
+
+  return modifiedSelector;
 }

--- a/test/modules.test.ts
+++ b/test/modules.test.ts
@@ -71,6 +71,14 @@ describe('globalifySelector', () => {
     );
     expect(globalifySelector(selector2)).toEqual(':global(div), :global(span)');
   });
+
+  it('correctly treats selectors with escaped combinator characters', async () => {
+    const selector1 = '.\\~positive.\\!normal ~ .\\+foo';
+
+    expect(globalifySelector(selector1)).toEqual(
+      ':global(.\\~positive.\\!normal) ~ :global(.\\+foo)',
+    );
+  });
 });
 
 describe(`parse svelte file`, () => {


### PR DESCRIPTION
BREAKING CHANGE: 🧨 Uses Lookbehind assertions, so Node 9.11.2+ is needed

✅ Closes: #191

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [x] Run the tests tests with `npm test` or `yarn test`
