### PR TITLE
Correct a wrong variable name in the example code

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -262,7 +262,7 @@ Voila! We can now reference a variable from our file without having to explicitl
 
 ```html
 <template>
-  h1 {world}
+  h1 {name}
 </template>
 
 <script>


### PR DESCRIPTION
The variable name in the code given as an example was wrong. It should be "name" instead of "world": {world} => {name}


