### PR TITLE
docs: fix broken link to "Usage" section

### DIFF
--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -24,7 +24,7 @@
 
 `svelte-preprocess` can be used in two ways: _auto-preprocessing_ and with _stand-alone_ processors.
 
-The examples below are going to be using a hypothetical `rollup.config.js`, but `svelte-preprocess` can be used in multiple scenarios, see "[Usage](usage.md)".
+The examples below are going to be using a hypothetical `rollup.config.js`, but `svelte-preprocess` can be used in multiple scenarios, see "[Usage](/docs/usage.md)".
 
 ## Preprocessor Modes
 

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -24,7 +24,7 @@
 
 `svelte-preprocess` can be used in two ways: _auto-preprocessing_ and with _stand-alone_ processors.
 
-The examples below are going to be using a hypothetical `rollup.config.js`, but `svelte-preprocess` can be used in multiple scenarios, see "[Usage](docs/usage.md)".
+The examples below are going to be using a hypothetical `rollup.config.js`, but `svelte-preprocess` can be used in multiple scenarios, see "[Usage](usage.md)".
 
 ## Preprocessor Modes
 


### PR DESCRIPTION
The path referring to `usage.md` was leading to a 404 page, due to it's path (`docs/usage.md`) being ambiguous to the current directory, solved it simply by removing the `docs/` portion of the path