### PR TITLE
feat: 🎸 add scss support for tilde (~) imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/ban-types": "off",
-    "no-console": "off"
+    "no-console": "off",
+    "line-comment-position": "off"
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [8, 10, 12]
+        node-version: [10, 12]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
-      - run: npm run test:ci
+      - uses: bahmutov/npm-install@v1
+      - run: npm run test
         env:
           CI: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+!/test/node_modules
 *.log
 coverage
 dist/

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "@types/pug": "^2.0.4",
     "@types/sass": "^1.16.0",
     "detect-indent": "^6.0.0",
-    "find-up": "^5.0.0",
     "strip-indent": "^3.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "build": "tsc --build tsconfig.build.json",
     "dev": "npm run build -- -w",
     "test": "jest",
-    "test:ci": "jest --silent --no-cache",
     "lint": "eslint --ext js,ts .",
     "format": "prettier --write \"**/*.{ts,js,json}\"",
     "postinstall": "echo \"[svelte-preprocess] Don't forget to install the preprocessors packages that will be used: node-sass/sass, stylus, less, postcss & postcss-load-config, coffeescript, pug, etc...\"",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@types/pug": "^2.0.4",
     "@types/sass": "^1.16.0",
     "detect-indent": "^6.0.0",
+    "find-up": "^5.0.0",
     "strip-indent": "^3.0.0"
   },
   "peerDependencies": {
@@ -137,9 +138,6 @@
       "optional": true
     },
     "sugarss": {
-      "optional": true
-    },
-    "svelte": {
       "optional": true
     },
     "typescript": {

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -1,4 +1,5 @@
-import { dirname } from 'path';
+import { existsSync } from 'fs';
+import { dirname, join, parse } from 'path';
 
 export async function importAny(...modules: string[]) {
   try {
@@ -66,4 +67,26 @@ export function isValidLocalPath(path: string) {
     !path.startsWith('{') &&
     !path.endsWith('}')
   );
+}
+
+// finds a existing path up the tree
+export function findUp({ what, from }) {
+  const { root, dir } = parse(from);
+  let cur = dir;
+
+  try {
+    while (cur !== root) {
+      const possiblePath = join(cur, what);
+
+      if (existsSync(possiblePath)) {
+        return possiblePath;
+      }
+
+      cur = dirname(cur);
+    }
+  } catch (e) {
+    console.error(e);
+  }
+
+  return null;
 }

--- a/src/transformers/scss.ts
+++ b/src/transformers/scss.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from 'path';
+import { dirname, join, sep } from 'path';
 import { existsSync } from 'fs';
 
 import type { Importer, Result } from 'sass';
@@ -29,15 +29,23 @@ const tildeImporter: Importer = (url, _prev) => {
     // not sure why this ends up here, but let's remove it
     _prev = _prev.replace('http://localhost', '');
 
+    if (process.platform === 'win32') {
+      _prev = decodeURIComponent(_prev);
+    }
+
     // possible dirs where a node_modules may live in, includes cwd
-    const possibleDirs = dirname(_prev).slice(cwd.length).split('/');
+    const possibleDirs = dirname(_prev).slice(cwd.length).split(sep);
 
     const existingNodeModules = possibleDirs
       // innermost dirs first
       .reverse()
       // return the first existing one
       .find((_, i, arr) => {
-        const absPath = join(cwd, ...arr.slice(0, i + 1), 'node_modules');
+        const absPath = join(
+          cwd,
+          ...arr.slice(0, i + sep.length),
+          'node_modules',
+        );
 
         return existsSync(absPath);
       });
@@ -49,7 +57,7 @@ const tildeImporter: Importer = (url, _prev) => {
       cwd,
       existingNodeModules,
       'node_modules',
-      url.slice(1),
+      url.slice(1).replace('/', sep),
     );
 
     return { file: resolvedUrl };

--- a/src/transformers/scss.ts
+++ b/src/transformers/scss.ts
@@ -19,12 +19,12 @@ function getResultForResolve(result: Result): ResolveResult {
   };
 }
 
-const tildeImporter: Importer = (url, _prev, done) => {
+const tildeImporter: Importer = (url, _prev) => {
   if (url.startsWith('~')) {
-    return done({ file: url.slice(1) });
+    return { file: url.slice(1) };
   }
 
-  return done({ file: url });
+  return { file: url };
 };
 
 const transformer: Transformer<Options.Sass> = async ({

--- a/src/transformers/scss.ts
+++ b/src/transformers/scss.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs';
 import { join } from 'path';
 
 import type { Importer, Result } from 'sass';
@@ -36,21 +37,12 @@ const tildeImporter: Importer = (url, prev) => {
     // todo: maybe create a smaller findup utility method?
     const foundPath = findUp.sync(modulePath, { cwd: prev });
 
-    console.log({
-      foundPath,
-      encoded: encodeURIComponent(foundPath),
-      modulePath,
-      prev,
-    });
-
     // istanbul ignore if
     if (foundPath == null) return null;
 
-    if (process.platform === 'win32') {
-      return { file: encodeURIComponent(foundPath) };
-    }
+    const contents = readFileSync(foundPath).toString();
 
-    return { file: foundPath };
+    return { contents };
   }
 
   return null;

--- a/test/node_modules/scss-package/main.scss
+++ b/test/node_modules/scss-package/main.scss
@@ -1,0 +1,1 @@
+div { color: pink; }

--- a/test/transformers/scss.test.ts
+++ b/test/transformers/scss.test.ts
@@ -108,4 +108,13 @@ describe('transformer - scss', () => {
 
     expect(preprocessed.toString()).toContain('div#green{color:green}');
   });
+
+  it('supports ~ tilde imports (removes the character)', async () => {
+    const template = `<style lang="scss">@import '~scss-package/main.scss'</style>`;
+    const opts = sveltePreprocess();
+
+    const preprocessed = await preprocess(template, opts);
+
+    expect(preprocessed.toString()).toContain('div{color:red}');
+  });
 });

--- a/test/transformers/scss.test.ts
+++ b/test/transformers/scss.test.ts
@@ -115,6 +115,10 @@ describe('transformer - scss', () => {
 
     const preprocessed = await preprocess(template, opts);
 
-    expect(preprocessed.toString()).toContain('div{color:red}');
+    expect(preprocessed.toString()).toMatchInlineSnapshot(`
+      "<style lang=\\"scss\\">div {
+        color: pink;
+      }</style>"
+    `);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3249,6 +3249,14 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 find-versions@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/find-versions/-/find-versions-3.2.0.tgz#10297f98030a786829681690545ef659ed1d254e"
@@ -4768,6 +4776,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -5423,6 +5438,13 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.0.2.tgz#1664e010af3cadc681baafd3e2a437be7b0fb5fe"
+  integrity sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -5443,6 +5465,13 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-map@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3249,14 +3249,6 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-find-up@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
-  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
-  dependencies:
-    locate-path "^6.0.0"
-    path-exists "^4.0.0"
-
 find-versions@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/find-versions/-/find-versions-3.2.0.tgz#10297f98030a786829681690545ef659ed1d254e"
@@ -4776,13 +4768,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-locate-path@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
-  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
-  dependencies:
-    p-locate "^5.0.0"
-
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -5438,13 +5423,6 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.0.2.tgz#1664e010af3cadc681baafd3e2a437be7b0fb5fe"
-  integrity sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==
-  dependencies:
-    p-try "^2.0.0"
-
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -5465,13 +5443,6 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
-
-p-locate@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
-  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
-  dependencies:
-    p-limit "^3.0.2"
 
 p-map@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
✅ Closes: #277

edit 1:
~Just gotta do a test for it 😁~

edit 2:
~Tests are failing now, not sure why. See https://github.com/sass/node-sass-middleware/issues/104~ Can't use the `done` for `renderSync` runs. 

Current challenge: 
it seems the sass compiler doesn't pass an importer's returned value through the `includePaths` paths, so it needs to return an absolute path. We use the `url` and `prev` (source) arguments to resolve it ~, but, for some reason, the `prev` value is coming as `stdin` instead of the importer path.~. Needed to pass `file` alongside the rest of the options.

edit 3:
Need to rewrite that importer, the logic is wrong. It will stop on the first node_modules found, even if there's no package with the specified path.

References:
https://github.com/matthewdavidson/node-sass-tilde-importer/blob/master/index.js
https://sass-lang.com/documentation/js-api#importer