### PR TITLE
Do not exclude node_modules from svelte-loader

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -51,7 +51,7 @@ export default {
       ...
       {
         test: /\.(html|svelte)$/,
-        exclude: /node_modules/,
+        exclude: [],
         use: {
           loader: 'svelte-loader',
           options: {


### PR DESCRIPTION
Updated docs so they don't exlcude node_modules from svelte-loader, because that makes it impossible to use Svelte components from NPM.

Also, see: https://github.com/sveltejs/template-webpack/commit/302038a740af4cff433c9d261cffc7f06f11ab9a#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166f