### PR TITLE
Fix VS Code warning

### DIFF
--- a/src/transformers/coffeescript.ts
+++ b/src/transformers/coffeescript.ts
@@ -25,9 +25,7 @@ const transformer: Transformer<Options.Coffeescript> = ({
     return { code, map };
   }
 
-  const code = coffeescript.compile(content, coffeeOptions);
-
-  return { code };
+  return { code: coffeescript.compile(content, coffeeOptions) };
 };
 
 export { transformer };


### PR DESCRIPTION
This fixes a VS Code warning I was getting:

> 'code' is already declared in the upper scope.