### PR TITLE
Sync preprocess

### DIFF
--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -39,7 +39,7 @@ const cachedResult: Record<string, boolean> = {};
  * @param {string} dep
  * @returns boolean
  */
-export async function hasDepInstalled(dep: string) {
+export function hasDepInstalled(dep: string) {
   if (cachedResult[dep] != null) {
     return cachedResult[dep];
   }
@@ -47,7 +47,7 @@ export async function hasDepInstalled(dep: string) {
   let result = false;
 
   try {
-    await import(dep);
+    require(dep);
 
     result = true;
   } catch (e) {

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { Processed } from './types';
+
+export type EventuallyProcessed<Sync> = Sync extends true
+  ? Processed
+  : Processed | Promise<Processed>;
+
+const pipe: <Sync>(
+  sync: Sync,
+  start: () => EventuallyProcessed<Sync>,
+  ...then: Array<(processed: Processed) => EventuallyProcessed<Sync>>
+) => EventuallyProcessed<Sync> = (sync, start, ...then) =>
+  ((sync ? pipe_sync : pipe_async) as any)(start, ...then);
+
+async function pipe_async(
+  start: () => Promise<Processed>,
+  ...then: Array<(processed: Processed) => Promise<Processed>>
+) {
+  let processed = await start();
+
+  for (let i = 0; i < then.length; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    processed = await then[i](processed);
+  }
+
+  return processed;
+}
+
+function pipe_sync(
+  start: () => Processed,
+  ...then: Array<(processed: Processed) => Processed>
+) {
+  let processed = start();
+
+  for (let i = 0; i < then.length; i++) {
+    processed = then[i](processed);
+  }
+
+  return processed;
+}
+
+export default pipe;

--- a/src/processors/pug.ts
+++ b/src/processors/pug.ts
@@ -15,6 +15,25 @@ export default (options?: Options.Pug): PreprocessorGroup => ({
       content,
     });
 
-    return transformMarkup({ content, filename }, transformer, options);
+    return transformMarkup(false, { content, filename }, transformer, options);
+  },
+
+  markup_sync({ content, filename }) {
+    const { transformer } = require('../transformers/pug');
+
+    content = prepareContent({
+      options: {
+        ...options,
+        stripIndent: true,
+      },
+      content,
+    });
+
+    return transformMarkup<true>(
+      true,
+      { content, filename },
+      transformer,
+      options,
+    );
   },
 });

--- a/src/processors/typescript.ts
+++ b/src/processors/typescript.ts
@@ -1,18 +1,14 @@
 import { Options, PreprocessorGroup } from '../types';
-import { getTagInfo } from '../modules/tagInfo';
+import { getTagInfoSync } from '../modules/tagInfo';
 import { concat } from '../modules/utils';
 import { prepareContent } from '../modules/prepareContent';
 
-export default (options?: Options.Typescript): PreprocessorGroup => ({
-  async script(svelteFile) {
-    const { transformer } = await import('../transformers/typescript');
-    let {
-      content,
-      filename,
-      attributes,
-      lang,
-      dependencies,
-    } = await getTagInfo(svelteFile);
+export default (options?: Options.Typescript): PreprocessorGroup => {
+  const script = (svelteFile) => {
+    const { transformer } = require('../transformers/typescript');
+    let { content, filename, attributes, lang, dependencies } = getTagInfoSync(
+      svelteFile,
+    );
 
     content = prepareContent({ options, content });
 
@@ -20,7 +16,7 @@ export default (options?: Options.Typescript): PreprocessorGroup => ({
       return { code: content };
     }
 
-    const transformed = await transformer({
+    const transformed = transformer({
       content,
       filename,
       attributes,
@@ -31,5 +27,10 @@ export default (options?: Options.Typescript): PreprocessorGroup => ({
       ...transformed,
       dependencies: concat(dependencies, transformed.dependencies),
     };
-  },
-});
+  };
+
+  return {
+    script,
+    script_sync: script,
+  };
+};

--- a/src/transformers/replace.ts
+++ b/src/transformers/replace.ts
@@ -1,9 +1,7 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { Transformer, Options } from '../types';
 
-const transformer: Transformer<Options.Replace> = async ({
-  content,
-  options,
-}) => {
+const transformer: Transformer<Options.Replace> = ({ content, options }) => {
   let newContent = content;
 
   for (const [regex, replacer] of options) {
@@ -15,4 +13,6 @@ const transformer: Transformer<Options.Replace> = async ({
   };
 };
 
-export { transformer };
+const is_sync = true;
+
+export { transformer, is_sync };

--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { dirname } from 'path';
 
 import ts from 'typescript';
@@ -151,4 +152,6 @@ const transformer: Transformer<Options.Typescript> = ({
   };
 };
 
-export { transformer };
+const is_sync = true;
+
+export { transformer, is_sync };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,6 +34,8 @@ export type Transformer<T> = (
   args: TransformerArgs<T>,
 ) => Processed | Promise<Processed>;
 
+export type SyncTransformer<T> = (args: TransformerArgs<T>) => Processed;
+
 export type TransformerOptions<T = any> = boolean | T | Transformer<T>;
 
 export interface Transformers {

--- a/test/autoProcess/externalFiles.test.ts
+++ b/test/autoProcess/externalFiles.test.ts
@@ -32,6 +32,7 @@ describe('external files', () => {
         <style src="./fixtures/style.css"></style>
         <script src="./fixtures/script.js"></script>`,
         filename: resolve(__dirname, '..', 'App.svelte'),
+        attributes: {},
       }),
       await scriptProcessor({
         content: ``,
@@ -57,6 +58,7 @@ describe('external files', () => {
     const markup = await markupProcessor({
       content: `<template src="./fixtures/template.html"/>`,
       filename: resolve(__dirname, '..', 'App.svelte'),
+      attributes: {},
     });
 
     expect(markup.code).toContain(getFixtureContent('template.html'));


### PR DESCRIPTION
This is a proposal for allowing synchronous preprocessing in order to solve sveltejs/kit#19 . It allows preprocessors to export synchronous versions of their processing functions. This allows the preprocessor to be used with e.g. `require.extensions`.

It goes together with sveltejs/svelte#5770

It's still a draft; tests are missing and the code could be refactored further. I'd like feedback as to whether this is a good idea before proceeding.

Getting TypeScript to play ball with functions that are sometimes sync and sometimes async was a bit messy, which IMO is the main argument against this solution.