### PR TITLE
sass: remove sourceMappingURL from result.code

### DIFF
--- a/src/transformers/scss.ts
+++ b/src/transformers/scss.ts
@@ -68,6 +68,7 @@ const transformer: Transformer<Options.Sass> = async ({
     ...options,
     includePaths: getIncludePaths(filename, options.includePaths),
     outFile: `${filename}.css`,
+    omitSourceMapUrl: true, // return sourcemap only in result.map
   };
 
   const sassOptions = {

--- a/src/transformers/scss.ts
+++ b/src/transformers/scss.ts
@@ -37,7 +37,6 @@ const tildeImporter: Importer = (url, prev) => {
 
   const modulePath = join('node_modules', ...url.slice(1).split(/[\\/]/g));
 
-  // todo: maybe create a smaller findup utility method?
   const foundPath = findUp({ what: modulePath, from: prev });
 
   // istanbul ignore if

--- a/test/transformers/scss.test.ts
+++ b/test/transformers/scss.test.ts
@@ -6,6 +6,7 @@ import { resolve } from 'path';
 import sveltePreprocess from '../../src';
 import { preprocess } from '../utils';
 import type { Options } from '../../src/types';
+import { transformer } from '../../src/transformers/scss';
 
 const implementation: Options.Sass['implementation'] = {
   render(options, callback) {
@@ -120,5 +121,18 @@ describe('transformer - scss', () => {
         color: pink;
       }</style>"
     `);
+  });
+
+  it('returns the source map and removes sourceMappingURL from code', async () => {
+    const content = 'div{color:red}';
+    const filename = '/file';
+    const options = {
+      sourceMap: true,
+    };
+
+    const { map, code } = await transformer({ content, filename, options });
+
+    expect(code).not.toContain('sourceMappingURL');
+    expect(map).toBeTruthy();
   });
 });


### PR DESCRIPTION
related to issue #286 and PR https://github.com/sveltejs/svelte/pull/5854

sourcemaps should be returned either in result.map or in result.code but not in both

keeping the `/*# sourceMappingURL=component.svelte.map */` magic comment 
~~makes the browser display wrong mappings~~
\*can\* make the browser display wrong mappings, if the sourcemap file exists (`component.svelte.map`)

~~(there is another bug with sourcemaps, so mappings are still wrong in the browser)~~
fixed by https://github.com/sveltejs/rollup-plugin-svelte/issues/175