### PR TITLE
fix typescript: translate options.sourceMap to options.compilerOptions.sourceMap (#286)

### DIFF
--- a/src/autoProcess.ts
+++ b/src/autoProcess.ts
@@ -131,9 +131,9 @@ export function sveltePreprocess(
       const pathParts = propPath.split('.');
       let parentObj = opts;
       let i;
-      for (i = 0; i < (pathParts.length - 1); i++) {
+      for (i = 0; i < pathParts.length - 1; i++) {
         const propName = pathParts[i];
-        if (typeof parentObj[propName] != 'object') parentObj[propName] = {};
+        if (typeof parentObj[propName] !== 'object') parentObj[propName] = {};
         parentObj = parentObj[propName];
       }
       const propName = pathParts[i];

--- a/src/autoProcess.ts
+++ b/src/autoProcess.ts
@@ -127,9 +127,17 @@ export function sveltePreprocess(
     }
 
     if (sourceMap && name in SOURCE_MAP_PROP_MAP) {
-      const [propName, value] = SOURCE_MAP_PROP_MAP[name];
-
-      opts[propName] = value;
+      const [propPath, value] = SOURCE_MAP_PROP_MAP[name];
+      const pathParts = propPath.split('.');
+      let parentObj = opts;
+      let i;
+      for (i = 0; i < (pathParts.length - 1); i++) {
+        const propName = pathParts[i];
+        if (typeof parentObj[propName] != 'object') parentObj[propName] = {};
+        parentObj = parentObj[propName];
+      }
+      const propName = pathParts[i];
+      parentObj[propName] = value;
     }
 
     return opts;

--- a/src/autoProcess.ts
+++ b/src/autoProcess.ts
@@ -7,7 +7,7 @@ import type {
   Transformers,
   Options,
 } from './types';
-import { hasDepInstalled, concat } from './modules/utils';
+import { hasDepInstalled, concat, setProp } from './modules/utils';
 import { getTagInfo } from './modules/tagInfo';
 import {
   addLanguageAlias,
@@ -127,23 +127,7 @@ export function sveltePreprocess(
     }
 
     if (sourceMap && name in SOURCE_MAP_PROP_MAP) {
-      const [propPath, value] = SOURCE_MAP_PROP_MAP[name];
-      const pathParts = propPath.split('.');
-      let parentObj = opts;
-
-      for (let i = 0; i < pathParts.length - 1; i++) {
-        const propName = pathParts[i];
-
-        if (typeof parentObj[propName] !== 'object') {
-          parentObj[propName] = {};
-        }
-
-        parentObj = parentObj[propName];
-      }
-
-      const propName = pathParts[pathParts.length - 1];
-
-      parentObj[propName] = value;
+      setProp(opts, ...SOURCE_MAP_PROP_MAP[name]);
     }
 
     return opts;

--- a/src/autoProcess.ts
+++ b/src/autoProcess.ts
@@ -130,13 +130,19 @@ export function sveltePreprocess(
       const [propPath, value] = SOURCE_MAP_PROP_MAP[name];
       const pathParts = propPath.split('.');
       let parentObj = opts;
-      let i;
-      for (i = 0; i < pathParts.length - 1; i++) {
+
+      for (let i = 0; i < pathParts.length - 1; i++) {
         const propName = pathParts[i];
-        if (typeof parentObj[propName] !== 'object') parentObj[propName] = {};
+
+        if (typeof parentObj[propName] !== 'object') {
+          parentObj[propName] = {};
+        }
+
         parentObj = parentObj[propName];
       }
-      const propName = pathParts[i];
+
+      const propName = pathParts[pathParts.length - 1];
+
       parentObj[propName] = value;
     }
 

--- a/src/modules/language.ts
+++ b/src/modules/language.ts
@@ -36,15 +36,15 @@ export function getLanguageDefaults(lang: string): null | Record<string, any> {
   return defaults;
 }
 
-export const SOURCE_MAP_PROP_MAP: Record<string, any[]> = {
-  babel: ['sourceMaps', true],
-  typescript: ['compilerOptions', 'sourceMap', true],
-  scss: ['sourceMap', true],
-  less: ['sourceMap', {}],
-  stylus: ['sourcemap', true],
-  postcss: ['map', true],
-  coffeescript: ['sourceMap', true],
-  globalStyle: ['sourceMap', true],
+export const SOURCE_MAP_PROP_MAP: Record<string, [string[], any]> = {
+  babel: [['sourceMaps'], true],
+  typescript: [['compilerOptions', 'sourceMap'], true],
+  scss: [['sourceMap'], true],
+  less: [['sourceMap'], {}],
+  stylus: [['sourcemap'], true],
+  postcss: [['map'], true],
+  coffeescript: [['sourceMap'], true],
+  globalStyle: [['sourceMap'], true],
 };
 
 export const ALIAS_MAP = new Map([

--- a/src/modules/language.ts
+++ b/src/modules/language.ts
@@ -38,7 +38,7 @@ export function getLanguageDefaults(lang: string): null | Record<string, any> {
 
 export const SOURCE_MAP_PROP_MAP: Record<string, [string, any]> = {
   babel: ['sourceMaps', true],
-  typescript: ['sourceMap', true],
+  typescript: ['compilerOptions.sourceMap', true],
   scss: ['sourceMap', true],
   less: ['sourceMap', {}],
   stylus: ['sourcemap', true],

--- a/src/modules/language.ts
+++ b/src/modules/language.ts
@@ -36,9 +36,9 @@ export function getLanguageDefaults(lang: string): null | Record<string, any> {
   return defaults;
 }
 
-export const SOURCE_MAP_PROP_MAP: Record<string, [string, any]> = {
+export const SOURCE_MAP_PROP_MAP: Record<string, any[]> = {
   babel: ['sourceMaps', true],
-  typescript: ['compilerOptions.sourceMap', true],
+  typescript: ['compilerOptions', 'sourceMap', true],
   scss: ['sourceMap', true],
   less: ['sourceMap', {}],
   stylus: ['sourcemap', true],

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -90,3 +90,21 @@ export function findUp({ what, from }) {
 
   return null;
 }
+
+// set deep property in object
+// args = array of prop-names, last arg = value
+export function setProp(obj, ...args) {
+  let i = 0;
+
+  for (; i < args.length - 2; i++) {
+    const key = args[i];
+
+    if (typeof obj[key] !== 'object') {
+      obj[key] = {};
+    }
+
+    obj = obj[key];
+  }
+
+  obj[args[i]] = args[i + 1];
+}

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -92,12 +92,11 @@ export function findUp({ what, from }) {
 }
 
 // set deep property in object
-// args = array of prop-names, last arg = value
-export function setProp(obj, ...args) {
+export function setProp(obj, keyList, val) {
   let i = 0;
 
-  for (; i < args.length - 2; i++) {
-    const key = args[i];
+  for (; i < keyList.length - 1; i++) {
+    const key = keyList[i];
 
     if (typeof obj[key] !== 'object') {
       obj[key] = {};
@@ -106,5 +105,5 @@ export function setProp(obj, ...args) {
     obj = obj[key];
   }
 
-  obj[args[i]] = args[i + 1];
+  obj[keyList[i]] = val;
 }

--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -62,6 +62,7 @@ const transformer: Transformer<Options.Typescript> = ({
   const compilerOptionsJSON = {
     moduleResolution: 'node',
     target: 'es6',
+    sourceMap: true, // generate sourcemap + attach '\n//# source'+'MappingURL=Component.svelte.js.map' to result.code
   };
 
   let basePath = process.cwd();

--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -105,7 +105,6 @@ const transformer: Transformer<Options.Typescript> = ({
     ...(convertedCompilerOptions as CompilerOptions),
     importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Error,
     allowNonTsExtensions: true,
-    sourceMap: !!options.sourceMap,
   };
 
   if (

--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -62,7 +62,6 @@ const transformer: Transformer<Options.Typescript> = ({
   const compilerOptionsJSON = {
     moduleResolution: 'node',
     target: 'es6',
-    sourceMap: true, // generate sourcemap + attach '\n//# source'+'MappingURL=Component.svelte.js.map' to result.code
   };
 
   let basePath = process.cwd();
@@ -106,6 +105,7 @@ const transformer: Transformer<Options.Typescript> = ({
     ...(convertedCompilerOptions as CompilerOptions),
     importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Error,
     allowNonTsExtensions: true,
+    sourceMap: !!options.sourceMap,
   };
 
   if (

--- a/test/autoProcess/sourceMaps.test.ts
+++ b/test/autoProcess/sourceMaps.test.ts
@@ -88,13 +88,16 @@ describe(`sourcemap generation`, () => {
         const expectedOptions = {};
         const pathParts = propPath.split('.');
         let parentObj = expectedOptions;
-        let i;
-        for (i = 0; i < pathParts.length - 1; i++) {
+
+        for (let i = 0; i < pathParts.length - 1; i++) {
           const propName = pathParts[i];
+
           parentObj[propName] = {};
           parentObj = parentObj[propName];
         }
-        const propName = pathParts[i];
+
+        const propName = pathParts[pathParts.length - 1];
+
         parentObj[propName] = value;
 
         await preprocess(template, opts);

--- a/test/autoProcess/sourceMaps.test.ts
+++ b/test/autoProcess/sourceMaps.test.ts
@@ -9,6 +9,7 @@ import { transformer as scssTransformer } from '../../src/transformers/scss';
 import { transformer as stylusTransformer } from '../../src/transformers/stylus';
 import { transformer as typescriptTransformer } from '../../src/transformers/typescript';
 import { SOURCE_MAP_PROP_MAP } from '../../src/modules/language';
+import { setProp } from '../../src/modules/utils';
 
 const TRANSFORMERS: Record<string, any> = {
   babel: {
@@ -84,21 +85,9 @@ describe(`sourcemap generation`, () => {
           [transformerName]: true,
         });
 
-        const [propPath, value] = SOURCE_MAP_PROP_MAP[transformerName];
         const expectedOptions = {};
-        const pathParts = propPath.split('.');
-        let parentObj = expectedOptions;
 
-        for (let i = 0; i < pathParts.length - 1; i++) {
-          const propName = pathParts[i];
-
-          parentObj[propName] = {};
-          parentObj = parentObj[propName];
-        }
-
-        const propName = pathParts[pathParts.length - 1];
-
-        parentObj[propName] = value;
+        setProp(expectedOptions, ...SOURCE_MAP_PROP_MAP[transformerName]);
 
         await preprocess(template, opts);
 

--- a/test/autoProcess/sourceMaps.test.ts
+++ b/test/autoProcess/sourceMaps.test.ts
@@ -84,13 +84,24 @@ describe(`sourcemap generation`, () => {
           [transformerName]: true,
         });
 
-        const [key, val] = SOURCE_MAP_PROP_MAP[transformerName];
+        const [propPath, value] = SOURCE_MAP_PROP_MAP[transformerName];
+        const expectedOptions = {};
+        const pathParts = propPath.split('.');
+        let parentObj = expectedOptions;
+        let i;
+        for (i = 0; i < pathParts.length - 1; i++) {
+          const propName = pathParts[i];
+          parentObj[propName] = {};
+          parentObj = parentObj[propName];
+        }
+        const propName = pathParts[i];
+        parentObj[propName] = value;
 
         await preprocess(template, opts);
 
         expect(transformer).toHaveBeenCalledWith(
           expect.objectContaining({
-            options: expect.objectContaining({ [key]: val }),
+            options: expect.objectContaining(expectedOptions),
           }),
         );
       });


### PR DESCRIPTION
trivial : )

edit: less trivial on second sight
in the old version, `sveltePreprocess({ sourceMap: true })` 
was translated to `transformer({ content, filename, options: { sourceMap: true } })`
but the typescript `transformer` function expects compiler-options in `options.compilerOptions`
so the correct translation is `transformer({ content, filename, options: { compilerOptions: { sourceMap: true } } })`
