### PR TITLE
fix: 🐛 language custom transformer overriding postcss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [4.6.7](https://github.com/sveltejs/svelte-preprocess/compare/v4.6.5...v4.6.7) (2021-02-10)
+
+
+### Bug Fixes
+
+* 🐛 language custom transformer overriding postcss ([2a188bc](https://github.com/sveltejs/svelte-preprocess/commit/2a188bc0886f9950ab3a23c9b24ac30a29dd81bb)), closes [#309](https://github.com/sveltejs/svelte-preprocess/issues/309)
+* accept postcss-load-config v2 or v3 ([#307](https://github.com/sveltejs/svelte-preprocess/issues/307)) ([a31e794](https://github.com/sveltejs/svelte-preprocess/commit/a31e79403f94cfd7db252a6152f120772acd4d6d))
+
+
+
 ## [4.6.6](https://github.com/sveltejs/svelte-preprocess/compare/v4.6.5...v4.6.6) (2021-02-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 ### Bug Fixes
 
 * 🐛 language custom transformer overriding postcss ([2a188bc](https://github.com/sveltejs/svelte-preprocess/commit/2a188bc0886f9950ab3a23c9b24ac30a29dd81bb)), closes [#309](https://github.com/sveltejs/svelte-preprocess/issues/309)
-* accept postcss-load-config v2 or v3 ([#307](https://github.com/sveltejs/svelte-preprocess/issues/307)) ([a31e794](https://github.com/sveltejs/svelte-preprocess/commit/a31e79403f94cfd7db252a6152f120772acd4d6d))
 
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-preprocess",
-  "version": "4.6.6",
+  "version": "4.6.7",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/modules/language.ts
+++ b/src/modules/language.ts
@@ -25,16 +25,16 @@ const LANGUAGE_DEFAULTS: Record<string, any> = {
   }),
 };
 
-export function getLanguageDefaults(lang: string): null | Record<string, any> {
-  const defaults = LANGUAGE_DEFAULTS[lang];
-
-  if (!defaults) return null;
-  if (typeof defaults === 'function') {
-    return defaults();
-  }
-
-  return defaults;
-}
+export const ALIAS_MAP = new Map([
+  ['pcss', 'css'],
+  ['postcss', 'css'],
+  ['sugarss', 'css'],
+  ['sass', 'scss'],
+  ['styl', 'stylus'],
+  ['js', 'javascript'],
+  ['coffee', 'coffeescript'],
+  ['ts', 'typescript'],
+]);
 
 export const SOURCE_MAP_PROP_MAP: Record<string, [string[], any]> = {
   babel: [['sourceMaps'], true],
@@ -47,23 +47,28 @@ export const SOURCE_MAP_PROP_MAP: Record<string, [string[], any]> = {
   globalStyle: [['sourceMap'], true],
 };
 
-export const ALIAS_MAP = new Map([
-  ['pcss', 'css'],
-  ['postcss', 'css'],
-  ['sugarss', 'css'],
-  ['sass', 'scss'],
-  ['styl', 'stylus'],
-  ['js', 'javascript'],
-  ['coffee', 'coffeescript'],
-  ['ts', 'typescript'],
-]);
+export function getLanguageDefaults(lang: string): null | Record<string, any> {
+  const defaults = LANGUAGE_DEFAULTS[lang];
 
-export const addLanguageAlias = (entries: Array<[string, string]>) =>
-  entries.forEach((entry) => ALIAS_MAP.set(...entry));
+  if (!defaults) return null;
+  if (typeof defaults === 'function') {
+    return defaults();
+  }
 
-export const getLanguageFromAlias = (alias: string | null) => {
+  return defaults;
+}
+
+export function addLanguageAlias(entries: Array<[string, string]>) {
+  return entries.forEach((entry) => ALIAS_MAP.set(...entry));
+}
+
+export function getLanguageFromAlias(alias: string | null) {
   return ALIAS_MAP.get(alias) || alias;
-};
+}
+
+export function isAliasOf(alias: string, lang: string) {
+  return lang !== alias && getLanguageFromAlias(alias) === lang;
+}
 
 export const getLanguage = (attributes: PreprocessorArgs['attributes']) => {
   let alias = null;

--- a/test/transformers/postcss.test.ts
+++ b/test/transformers/postcss.test.ts
@@ -149,3 +149,31 @@ test('automatically removes indentation for lang=sugarss', async () => {
       }</style>"
     `);
 });
+
+test('should not override postcss with custom style language', async () => {
+  const custom = jest.fn(({ content }) => ({ code: content }));
+  const postcss = jest.fn(({ content }) => ({ code: content }));
+  const opts = sveltePreprocess({ custom, postcss });
+
+  await preprocess(
+    `<div></div><style lang="custom">div{color:red}</style>`,
+    opts,
+  );
+
+  expect(custom).toHaveBeenCalledTimes(1);
+  expect(postcss).toHaveBeenCalledTimes(1);
+});
+
+test('should execute postcss alias override before postcss', async () => {
+  const sugarss = jest.fn(({ content }) => ({ code: content }));
+  const postcss = jest.fn(({ content }) => ({ code: content }));
+  const opts = sveltePreprocess({ sugarss, postcss });
+
+  await preprocess(
+    `<div></div><style lang="sugarss">div{color:red}</style>`,
+    opts,
+  );
+
+  expect(sugarss).toHaveBeenCalledTimes(1);
+  expect(postcss).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
Fixing this made me think it's time for a major rethink/rewrite on how we run the transformers in auto preprocess mode. The current way to run postcss after a style preprocessor seems brittle and, for a lack of a better word, wrong. 

