### PR TITLE
fix destructuring errors in esbuild example in preprocessing.md

### DIFF
--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -155,12 +155,11 @@ export default {
   plugins: [
     svelte({
       preprocess: sveltePreprocess({
-        typescript({ content, filename }) {
-          const { js: code } = transformSync(content, {
+        typescript({ content }) {
+          const { code, map } = transformSync(content, {
             loader: 'ts',
           });
-
-          return { code };
+          return { code, map };
         },
       }),
     }),


### PR DESCRIPTION
In the `preprocessing.md` doc there seems to be a destructuring error. 

```javascript
const { js: code } //... js doesn't exist
return { code };
```
Using the code above makes it so that the compiler throws errors. The latest esbuild [transform api](https://esbuild.github.io/api/#transform-api) doesn't return an object with the `js` property but instead has the `code` property. 

The small changes below fixes the error and actually mirrors some of the code in the *custom preprocessors* section slightly above the esbuild example.
```javascript
const { code, map } = //...
```
