### PR TITLE
Docs: getting-started.md - Change examples to use {name} variable

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -128,7 +128,7 @@ And we're done! Our components can now be written as:
 
 ```html
 <template lang="pug">
-  h1 {world}
+  h1 {name}
 </template>
 
 <script lang="ts">
@@ -189,7 +189,7 @@ Now our components are a bit leaner!
 
 ```html
 <template>
-  h1 {world}
+  h1 {name}
 </template>
 
 <script>


### PR DESCRIPTION
I'm following the final example on this page, which uses {name} in the template. I don't think there's a `world` variable, but I could be wrong 🌎
