### PR TITLE
(feat) Support tsconfig extends

### DIFF
--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -70,6 +70,7 @@ export function loadTsconfig(
   let tsconfigFile =
     tsOptions.tsconfigFile ||
     ts.findConfigFile(fileDirectory, ts.sys.fileExists);
+
   tsconfigFile = isAbsolute(tsconfigFile)
     ? tsconfigFile
     : join(basePath, tsconfigFile);
@@ -92,6 +93,7 @@ export function loadTsconfig(
     compilerOptionsJSON,
     tsconfigFile,
   );
+
   // Filter out "no files found error"
   errors = errors.filter((d) => d.code !== 18003);
 
@@ -109,7 +111,8 @@ const transformer: Transformer<Options.Typescript> = ({
     target: 'es6',
   };
 
-  let basePath = process.cwd();
+  const basePath = process.cwd();
+
   Object.assign(compilerOptionsJSON, options.compilerOptions);
 
   const { errors, options: convertedCompilerOptions } =

--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -1,4 +1,4 @@
-import { dirname } from 'path';
+import { dirname, isAbsolute, join } from 'path';
 
 import ts from 'typescript';
 
@@ -53,6 +53,51 @@ const importTransformer: ts.TransformerFactory<ts.SourceFile> = (context) => {
   return (node) => ts.visitNode(node, visit);
 };
 
+export function loadTsconfig(
+  compilerOptionsJSON: any,
+  filename: string,
+  tsOptions: Options.Typescript,
+) {
+  if (typeof tsOptions.tsconfigFile === 'boolean') {
+    return { errors: [], options: compilerOptionsJSON };
+  }
+
+  let basePath = process.cwd();
+
+  const fileDirectory = (tsOptions.tsconfigDirectory ||
+    dirname(filename)) as string;
+
+  let tsconfigFile =
+    tsOptions.tsconfigFile ||
+    ts.findConfigFile(fileDirectory, ts.sys.fileExists);
+  tsconfigFile = isAbsolute(tsconfigFile)
+    ? tsconfigFile
+    : join(basePath, tsconfigFile);
+
+  basePath = dirname(tsconfigFile);
+
+  const { error, config } = ts.readConfigFile(tsconfigFile, ts.sys.readFile);
+
+  if (error) {
+    throw new Error(formatDiagnostics(error, basePath));
+  }
+
+  // Do this so TS will not search for initial files which might take a while
+  config.include = [];
+
+  let { errors, options } = ts.parseJsonConfigFileContent(
+    config,
+    ts.sys,
+    basePath,
+    compilerOptionsJSON,
+    tsconfigFile,
+  );
+  // Filter out "no files found error"
+  errors = errors.filter((d) => d.code !== 18003);
+
+  return { errors, options };
+}
+
 const transformer: Transformer<Options.Typescript> = ({
   content,
   filename,
@@ -65,37 +110,12 @@ const transformer: Transformer<Options.Typescript> = ({
   };
 
   let basePath = process.cwd();
-
-  if (options.tsconfigFile !== false || options.tsconfigDirectory) {
-    const fileDirectory = (options.tsconfigDirectory ||
-      dirname(filename)) as string;
-
-    const tsconfigFile =
-      options.tsconfigFile ||
-      ts.findConfigFile(fileDirectory, ts.sys.fileExists);
-
-    if (typeof tsconfigFile === 'string') {
-      basePath = dirname(tsconfigFile);
-
-      const { error, config } = ts.readConfigFile(
-        tsconfigFile,
-        ts.sys.readFile,
-      );
-
-      if (error) {
-        throw new Error(formatDiagnostics(error, basePath));
-      }
-
-      Object.assign(compilerOptionsJSON, config.compilerOptions);
-    }
-  }
-
   Object.assign(compilerOptionsJSON, options.compilerOptions);
 
-  const {
-    errors,
-    options: convertedCompilerOptions,
-  } = ts.convertCompilerOptionsFromJson(compilerOptionsJSON, basePath);
+  const { errors, options: convertedCompilerOptions } =
+    options.tsconfigFile !== false || options.tsconfigDirectory
+      ? loadTsconfig(compilerOptionsJSON, filename, options)
+      : ts.convertCompilerOptionsFromJson(compilerOptionsJSON, basePath);
 
   if (errors.length) {
     throw new Error(formatDiagnostics(errors, basePath));

--- a/test/fixtures/tsconfig.extends1.json
+++ b/test/fixtures/tsconfig.extends1.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.extends2.json",
+  "compilerOptions": {
+    "esModuleInterop": true,
+  }
+}

--- a/test/fixtures/tsconfig.extends2.json
+++ b/test/fixtures/tsconfig.extends2.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": false,
+  }
+}

--- a/test/transformers/typescript.test.ts
+++ b/test/transformers/typescript.test.ts
@@ -3,8 +3,14 @@ import { resolve } from 'path';
 import type { Diagnostic } from 'typescript';
 
 import sveltePreprocess from '../../src';
+import { loadTsconfig } from '../../src/transformers/typescript';
 import type { Processed } from '../../src/types';
-import { preprocess, getFixtureContent, spyConsole } from '../utils';
+import {
+  preprocess,
+  getFixtureContent,
+  spyConsole,
+  getTestAppFilename,
+} from '../utils';
 
 spyConsole({ silent: true });
 
@@ -102,6 +108,18 @@ describe('transformer - typescript', () => {
       const { code } = await preprocess(template, opts);
 
       return expect(code).toContain(getFixtureContent('script.js'));
+    });
+
+    it('supports extends field', () => {
+      const { options } = loadTsconfig({}, getTestAppFilename(), {
+        tsconfigFile: './test/fixtures/tsconfig.extends1.json',
+      });
+
+      expect(options).toMatchObject({
+        module: 5,
+        skipLibCheck: false,
+        esModuleInterop: true,
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes #300

I was unsure about the boolean/string behavior of the options, especially because it is mentioned nowhere in the docs that boolean is a valid option.

Also, if I understand this correctly, by default the tsconfig.json is not picked up if I do `sveltePreprocess()`?

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [x] Run the tests with `npm test` or `yarn test`
