### PR TITLE
WIP: Improve TypeScript imports preprocessing (#318) 

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,8 @@
     "@types/pug": "^2.0.4",
     "@types/sass": "^1.16.0",
     "detect-indent": "^6.0.0",
+    "magic-string": "^0.25.7",
+    "sorcery": "^0.10.0",
     "strip-indent": "^3.0.0"
   },
   "peerDependencies": {

--- a/src/autoProcess.ts
+++ b/src/autoProcess.ts
@@ -60,7 +60,7 @@ type AutoPreprocessOptions = {
 export const transform = async (
   name: string,
   options: TransformerOptions,
-  { content, map, filename, attributes }: TransformerArgs<any>,
+  { content, markup, map, filename, attributes }: TransformerArgs<any>,
 ): Promise<Processed> => {
   if (options === false) {
     return { code: content };
@@ -75,6 +75,7 @@ export const transform = async (
 
   return transformer({
     content,
+    markup,
     filename,
     map,
     attributes,
@@ -151,6 +152,7 @@ export function sveltePreprocess(
   ): Preprocessor => async (svelteFile) => {
     let {
       content,
+      markup,
       filename,
       lang,
       alias,
@@ -187,6 +189,7 @@ export function sveltePreprocess(
 
     const transformed = await transform(lang, transformerOptions, {
       content,
+      markup,
       filename,
       attributes,
     });
@@ -205,6 +208,7 @@ export function sveltePreprocess(
     if (transformers.replace) {
       const transformed = await transform('replace', transformers.replace, {
         content,
+        markup: content,
         filename,
       });
 
@@ -221,11 +225,13 @@ export function sveltePreprocess(
   const script: PreprocessorGroup['script'] = async ({
     content,
     attributes,
+    markup: fullMarkup,
     filename,
   }) => {
     const transformResult: Processed = await scriptTransformer({
       content,
       attributes,
+      markup: fullMarkup,
       filename,
     });
 
@@ -235,7 +241,7 @@ export function sveltePreprocess(
       const transformed = await transform(
         'babel',
         getTransformerOptions('babel'),
-        { content: code, map, filename, attributes },
+        { content: code, markup: fullMarkup, map, filename, attributes },
       );
 
       code = transformed.code;
@@ -250,11 +256,13 @@ export function sveltePreprocess(
   const style: PreprocessorGroup['style'] = async ({
     content,
     attributes,
+    markup: fullMarkup,
     filename,
   }) => {
     const transformResult = await cssTransformer({
       content,
       attributes,
+      markup: fullMarkup,
       filename,
     });
 
@@ -275,6 +283,7 @@ export function sveltePreprocess(
 
         const transformed = await transform('postcss', postcssOptions, {
           content: code,
+          markup: fullMarkup,
           map,
           filename,
           attributes,
@@ -288,7 +297,7 @@ export function sveltePreprocess(
       const transformed = await transform(
         'globalStyle',
         getTransformerOptions('globalStyle'),
-        { content: code, map, filename, attributes },
+        { content: code, markup: fullMarkup, map, filename, attributes },
       );
 
       code = transformed.code;

--- a/src/modules/markup.ts
+++ b/src/modules/markup.ts
@@ -1,5 +1,35 @@
 import type { Transformer, Preprocessor } from '../types';
 
+/** Create a tag matching regexp. */
+export function createTagRegex(tagName: string, flags?: string): RegExp {
+  return new RegExp(
+    `<!--[^]*?-->|<${tagName}(\\s[^]*?)?(?:>([^]*?)<\\/${tagName}>|\\/>)`,
+    flags,
+  );
+}
+
+/** Strip script and style tags from markup. */
+export function stripTags(markup: string): string {
+  return markup
+    .replace(createTagRegex('style', 'gi'), '')
+    .replace(createTagRegex('script', 'gi'), '');
+}
+
+/** Transform an attribute string into a key-value object */
+export function parseAttributes(attributesStr: string): Record<string, any> {
+  return attributesStr
+    .split(/\s+/)
+    .filter(Boolean)
+    .reduce((acc: Record<string, string | boolean>, attr) => {
+      const [name, value] = attr.split('=');
+
+      // istanbul ignore next
+      acc[name] = value ? value.replace(/['"]/g, '') : true;
+
+      return acc;
+    }, {});
+}
+
 export async function transformMarkup(
   { content, filename }: { content: string; filename: string },
   transformer: Preprocessor | Transformer<unknown>,
@@ -9,9 +39,7 @@ export async function transformMarkup(
 
   markupTagName = markupTagName.toLocaleLowerCase();
 
-  const markupPattern = new RegExp(
-    `/<!--[^]*?-->|<${markupTagName}(\\s[^]*?)?(?:>([^]*?)<\\/${markupTagName}>|\\/>)`,
-  );
+  const markupPattern = createTagRegex(markupTagName);
 
   const templateMatch = content.match(markupPattern);
 
@@ -28,18 +56,7 @@ export async function transformMarkup(
 
   const [fullMatch, attributesStr = '', templateCode] = templateMatch;
 
-  /** Transform an attribute string into a key-value object */
-  const attributes = attributesStr
-    .split(/\s+/)
-    .filter(Boolean)
-    .reduce((acc: Record<string, string | boolean>, attr) => {
-      const [name, value] = attr.split('=');
-
-      // istanbul ignore next
-      acc[name] = value ? value.replace(/['"]/g, '') : true;
-
-      return acc;
-    }, {});
+  const attributes = parseAttributes(attributesStr);
 
   /** Transform the found template code */
   let { code, map, dependencies } = await transformer({

--- a/src/modules/markup.ts
+++ b/src/modules/markup.ts
@@ -17,7 +17,13 @@ export async function transformMarkup(
 
   /** If no <template> was found, run the transformer over the whole thing */
   if (!templateMatch) {
-    return transformer({ content, attributes: {}, filename, options });
+    return transformer({
+      content,
+      markup: content,
+      attributes: {},
+      filename,
+      options,
+    });
   }
 
   const [fullMatch, attributesStr = '', templateCode] = templateMatch;
@@ -38,6 +44,7 @@ export async function transformMarkup(
   /** Transform the found template code */
   let { code, map, dependencies } = await transformer({
     content: templateCode,
+    markup: templateCode,
     attributes,
     filename,
     options,

--- a/src/modules/tagInfo.ts
+++ b/src/modules/tagInfo.ts
@@ -27,6 +27,7 @@ export const getTagInfo = async ({
   attributes,
   filename,
   content,
+  markup,
 }: PreprocessorArgs) => {
   const dependencies = [];
   // catches empty content and self-closing tags
@@ -62,5 +63,6 @@ export const getTagInfo = async ({
     lang,
     alias,
     dependencies,
+    markup,
   };
 };

--- a/src/processors/typescript.ts
+++ b/src/processors/typescript.ts
@@ -8,6 +8,7 @@ export default (options?: Options.Typescript): PreprocessorGroup => ({
     const { transformer } = await import('../transformers/typescript');
     let {
       content,
+      markup,
       filename,
       attributes,
       lang,
@@ -22,6 +23,7 @@ export default (options?: Options.Typescript): PreprocessorGroup => ({
 
     const transformed = await transformer({
       content,
+      markup,
       filename,
       attributes,
       options,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,7 @@ export type TransformerArgs<T> = {
   filename: string;
   attributes?: Record<string, any>;
   map?: string | object;
+  markup?: string;
   dianostics?: unknown[];
   options?: T;
 };

--- a/test/autoProcess/externalFiles.test.ts
+++ b/test/autoProcess/externalFiles.test.ts
@@ -26,20 +26,24 @@ describe('external files', () => {
   afterEach(warnSpy.mockClear);
 
   it('should insert external file content and add as deps', async () => {
+    const code = `<template src="./fixtures/template.html"></template>
+    <style src="./fixtures/style.css"></style>
+    <script src="./fixtures/script.js"></script>`;
+
     const [markup, script, style] = [
       await markupProcessor({
-        content: `<template src="./fixtures/template.html"></template>
-        <style src="./fixtures/style.css"></style>
-        <script src="./fixtures/script.js"></script>`,
+        content: code,
         filename: resolve(__dirname, '..', 'App.svelte'),
       }),
       await scriptProcessor({
         content: ``,
+        markup: code,
         filename: resolve(__dirname, '..', 'App.svelte'),
         attributes: { src: `./fixtures/script.js` },
       }),
       await styleProcessor({
         content: ``,
+        markup: code,
         filename: resolve(__dirname, '..', 'App.svelte'),
         attributes: { src: `./fixtures/style.css` },
       }),

--- a/test/fixtures/TypeScriptImports.svelte
+++ b/test/fixtures/TypeScriptImports.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+    import { fly } from "svelte/transition";
+    import { flip } from "svelte/animate";
+    import Nested from "./Nested.svelte";
+    import { hello } from "./script";
+    import { AValue, AType } from "./types";
+    const ui = { MyNested: Nested };
+    const val: AType = "test1";
+    const prom: Promise<AType> = Promise.resolve("test2");
+    const arr: AType[] = ["test1", "test2"];
+    const isTest1 = (v: AType) => v === "test1";
+    const obj = {
+        fn: () => "test",
+        val: "test1" as const
+    };
+    let inputVal: string;
+    const action = (node: Element, options: { id: string; }) => { node.id = options.id; };
+    const action2 = (node: Element) => { node.classList.add("test"); };
+    let nested: Nested;
+    
+    let scrollY = 500;
+    let innerWidth = 500;
+    
+    const duration = 200;
+    function onKeyDown(e: KeyboardEvent): void {
+        e.preventDefault();
+    }
+</script>
+
+<style>
+    .value { color: #ccc; }
+</style>
+
+<svelte:window on:keydown={onKeyDown} {scrollY} bind:innerWidth />
+<svelte:body on:keydown={onKeyDown} />
+
+<svelte:head>
+    <title>Title: {val}</title>
+</svelte:head>
+
+<div>
+    <Nested let:var1 let:var2={var3}>
+        <Nested bind:this={nested} />
+        <Nested {...obj} />
+        <Nested {...{ var1, var3 }} />
+
+        <svelte:fragment slot="slot1" let:var4={var5}>
+            <Nested {...{ var5 }} />
+        </svelte:fragment>
+
+        <div slot="slot2" let:var6={var7}>
+            <Nested {...{ var7 }} />
+        </div>
+
+        <div slot="slot3">
+            <Nested {...{ val }} />
+        </div>
+    </Nested>
+
+    <svelte:component this={ui.MyNested} {val} on:keydown={onKeyDown} bind:inputVal />
+
+    <p class:value={!!inputVal}>{hello}</p>
+    <input bind:value={inputVal} use:action={{ id: val }} use:action2 />
+
+    {#if AValue && val}
+        <p class="value" transition:fly={{ duration }}>There is a value: {AValue}</p>
+    {/if}
+
+    {#if val && isTest1(val) && AValue && true && "test"}
+        <p class="value">There is a value: {AValue}</p>
+    {:else if obj.val && obj.fn() && isTest1(obj.val)}
+        <p class="value">There is a value: {AValue}</p>
+    {:else}
+        Else
+    {/if}
+
+    {#each arr as item (item)}
+        <p animate:flip={{ duration }}>{item}</p>
+    {/each}
+
+    {#each arr as item}
+        <p>{item}</p>
+    {:else}
+        <p>No items</p>
+    {/each}
+
+    {#await prom}
+        Loading...
+    {:then value} 
+        <input type={val} {value} on:input={e => inputVal = e.currentTarget.value} />
+    {:catch err}
+        <p>Error: {err}</p>
+    {/await}
+
+    {#await prom then value}
+        <p>{value}</p>
+    {/await}
+
+    {#key val}
+        <p>Keyed {val}</p>
+    {/key}
+
+    <slot name="slot0" {inputVal}>
+        <p>{inputVal}</p>
+    </slot>
+
+    {@html val}
+    {@debug val, inputVal}
+</div>

--- a/test/fixtures/TypeScriptImportsModule.svelte
+++ b/test/fixtures/TypeScriptImportsModule.svelte
@@ -1,0 +1,10 @@
+<script lang="ts" context="module">
+    import { AValue, AType } from "./types";
+</script>
+
+<script lang="ts">
+    const val: AType = "test1";
+    const aValue = AValue;
+</script>
+
+{val} {aValue}

--- a/test/modules/modules.test.ts
+++ b/test/modules/modules.test.ts
@@ -59,6 +59,7 @@ describe(`get tag information`, () => {
   it('should only include src files if content is empty', async () => {
     let parsedFile = await getTagInfo({
       content: '',
+      markup: '',
       attributes: { src: './fixtures/style.scss' },
       filename: getTestAppFilename(),
     });

--- a/test/transformers/typescript.test.ts
+++ b/test/transformers/typescript.test.ts
@@ -111,6 +111,24 @@ describe('transformer - typescript', () => {
       return expect(code).toContain(getFixtureContent('script.js'));
     });
 
+    it('should strip unused and type imports', async () => {
+      const tpl = getFixtureContent('TypeScriptImports.svelte');
+
+      const opts = sveltePreprocess({ typescript: { tsconfigFile: false } });
+      const { code } = await preprocess(tpl, opts);
+
+      return expect(code).toContain(`import { AValue } from "./types";`);
+    });
+
+    it('should strip unused and type imports in context="module" tags', async () => {
+      const tpl = getFixtureContent('TypeScriptImportsModule.svelte');
+
+      const opts = sveltePreprocess({ typescript: { tsconfigFile: false } });
+      const { code } = await preprocess(tpl, opts);
+
+      return expect(code).toContain(`import { AValue } from "./types";`);
+    });
+
     it('supports extends field', () => {
       const { options } = loadTsconfig({}, getTestAppFilename(), {
         tsconfigFile: './test/fixtures/tsconfig.extends1.json',

--- a/test/transformers/typescript.test.ts
+++ b/test/transformers/typescript.test.ts
@@ -29,6 +29,7 @@ const autoProcessTS = (content: string, compilerOptions?: any) => {
 
   return opts.script({
     content,
+    markup: `<script lang="ts">${content}</script>`,
     attributes: { type: 'text/typescript' },
     filename: resolve(__dirname, '..', 'App.svelte'),
   }) as Processed & { diagnostics: Diagnostic[] };

--- a/test/transformers/typescript.test.ts
+++ b/test/transformers/typescript.test.ts
@@ -129,6 +129,19 @@ describe('transformer - typescript', () => {
       return expect(code).toContain(`import { AValue } from "./types";`);
     });
 
+    it('should produce sourcemap', async () => {
+      const tpl = getFixtureContent('TypeScriptImportsModule.svelte');
+
+      const opts = sveltePreprocess({
+        typescript: { tsconfigFile: false },
+        sourceMap: true,
+      });
+
+      const { map } = await preprocess(tpl, opts);
+
+      return expect(map).toHaveProperty('sources', ['App.svelte']);
+    });
+
     it('supports extends field', () => {
       const { options } = loadTsconfig({}, getTestAppFilename(), {
         tsconfigFile: './test/fixtures/tsconfig.extends1.json',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2008,6 +2008,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-crc32@^0.2.5:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
+
 buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -2860,6 +2865,11 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es6-promise@^3.1.2:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
+  integrity sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=
+
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -3593,6 +3603,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
+
+graceful-fs@^4.1.3:
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
+  integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -4927,6 +4942,13 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+magic-string@^0.25.7:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
 
 make-dir@^2.1.0:
   version "2.1.0"
@@ -6355,7 +6377,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@2:
+rimraf@2, rimraf@^2.5.2:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -6407,6 +6429,16 @@ safe-regex@^1.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sander@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/sander/-/sander-0.5.1.tgz#741e245e231f07cafb6fdf0f133adfa216a502ad"
+  integrity sha1-dB4kXiMfB8r7b98PEzrfohalAq0=
+  dependencies:
+    es6-promise "^3.1.2"
+    graceful-fs "^4.1.3"
+    mkdirp "^0.5.1"
+    rimraf "^2.5.2"
 
 sane@^4.0.3:
   version "4.1.0"
@@ -6622,6 +6654,16 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
+sorcery@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/sorcery/-/sorcery-0.10.0.tgz#8ae90ad7d7cb05fc59f1ab0c637845d5c15a52b7"
+  integrity sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=
+  dependencies:
+    buffer-crc32 "^0.2.5"
+    minimist "^1.2.0"
+    sander "^0.5.0"
+    sourcemap-codec "^1.3.0"
+
 source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
@@ -6667,6 +6709,11 @@ source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+sourcemap-codec@^1.3.0, sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 spdx-correct@^3.0.0:
   version "3.1.1"


### PR DESCRIPTION
**/!\ This is a work-in-progress. DO NOT MERGE!**

### Introduction

I open this PR to init the work and the collaboration on a resolution for #318.

***Note:** This implementation requires an unreleased version of svelte to work.*
***Note 2:** You will find below a way to setup a test environment to test this implementation on your projects.*

### Background

Thanks to @dummdidumm advices, I added 3 features on `svelte`, some have been merged, some are waiting for review:
- [X] sveltejs/svelte#6169
- [ ] sveltejs/svelte#6192
- [ ] sveltejs/svelte#6194

These features enable 2 required things:
1. It makes `svelte` pass the full source markup to preprocessors
2. It allows to use `svelte.compile` to get a full report of used variables in markup

### Description

This PR makes two improvements.

First, it takes the markup passed by `svelte` and make it available to transformers.
This markup is optional here to be backward compatible with previous versions of `svelte`.

Then, it uses the full markup, strips the `script` and `style` tags and pass it to `svelte.compile` to get a report of all used variables in the template. This list of variables is appended to the TypeScript code to allow the TypeScript compiler to correctly handle imports. Thanks to this, we can remove the custom `importTransformer` when `markup` is available.

### TODO

This is a work in progress.
First of all, it needs above PRs to be merged and released on `svelte` side.

Then, it misses some cases:
- [x] Handling `context="module"` scripts
- [x] Stripping the injected code from sourcemaps
- [x] Adding more tests
- [ ] Testing on real-world project

For this last task, I will need the help of the community 😉.

I also have very few experience on sourcemap manipulation so if someone can help on this...

### Setup test environment

If you want to test working on this PR, you will need to do the following:
```bash
# Clone the fork with all svelte PRs merged
git clone https://github.com/SomaticIT/svelte.git
cd svelte

# Switch to the appropriate branch
git checkout @release/custom

# Prepare the project
npm install
npm run build

# Link the project globally
npm link

# Clone the fork of svelte-preprocess
cd ..
git clone https://github.com/SomaticIT/svelte-preprocess.git
cd svelte-preprocess

# Switch to the appropriate branch
git checkout @feature/typescript-imports

# Link svelte locally
npm link svelte
```

If you want to test this feature in your project (I will need your feedbacks):
```bash
# Do the previous steps then from the svelte-preprocess dir
npm run build
npm link

# In your project dir
npm link svelte
npm link svelte-preprocess
```

### Performances impact

On my computer, I benchmarked the preprocessing of this svelte file: `test/fixtures/TypeScriptImports.svelte`.
Before this PR: **~30ms**
After this PR: **~55ms**

### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [X] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [X] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [X] Run the tests with `npm test` or `yarn test`