### PR TITLE
Clarify usage of svelte.config.js

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,7 +7,8 @@
 - [With `rollup-plugin-svelte`](#with-rollup-plugin-svelte)
 - [With `svelte-loader`](#with-svelte-loader)
 - [With Sapper](#with-sapper)
-- [With Svelte VS Code](#with-svelte-vs-code)
+- [With Svelte VS Code](#with-svelte-config)
+- [With Svelte Kit](#with-svelte-config)
 
 <!-- /code_chunk_output -->
 
@@ -99,9 +100,11 @@ export default {
 };
 ```
 
-## With Svelte VS Code
+## With Svelte Config
 
-[svelte-vscode](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode) needs to know how its (svelte) language server should preprocess your files. This can be achieved by creating a `svelte.config.js` file at the root of your project which exports a svelte options object (similar to `svelte-loader` and `rollup-plugin-svelte`).
+Useful for [svelte-vscode](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode) which needs to know how its (svelte) language server should preprocess your files and [svelte-kit](https://github.com/sveltejs/kit) which can preprocess your svelte files prior to building.
+
+This can be achieved by creating a `svelte.config.js` file at the root of your project which exports a svelte options object (similar to `svelte-loader` and `rollup-plugin-svelte`).
 
 **Example**:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -102,9 +102,7 @@ export default {
 
 ## With Svelte Config
 
-Useful for [svelte-vscode](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode) which needs to know how its (svelte) language server should preprocess your files and [svelte-kit](https://github.com/sveltejs/kit) which can preprocess your svelte files prior to building.
-
-This can be achieved by creating a `svelte.config.js` file at the root of your project which exports a svelte options object (similar to `svelte-loader` and `rollup-plugin-svelte`).
+Some tools of the Svelte ecosystem, such as [svelte-vscode](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode) and [svelte-kit](https://github.com/sveltejs/kit), need access to your svelte configuration so they know how to properly handle your Svelte files. This can be achieved by creating a `svelte.config.js` file at the root of your project which exports a svelte options object (similar to `svelte-loader` and `rollup-plugin-svelte`).
 
 **Example**:
 


### PR DESCRIPTION
Make it clear that svelte.config.js instructions work for vscode and kit as I didn't see this anywhere else.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [ ] Run the tests with `npm test` or `yarn test`
