### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           cache: npm
       - uses: bahmutov/npm-install@v1
-      - run: "npm run lint"
+      - run: 'npm run lint'
 
   Tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v2
+        with:
+          cache: npm
       - uses: bahmutov/npm-install@v1
-      - run: 'npm run lint'
+      - run: "npm run lint"
 
   Tests:
     runs-on: ${{ matrix.os }}
@@ -24,6 +26,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - uses: bahmutov/npm-install@v1
       - run: npm run test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           cache: npm
-      - uses: bahmutov/npm-install@v1
+      - run: npm ci
       - run: 'npm run lint'
 
   Tests:
@@ -27,7 +27,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
-      - uses: bahmutov/npm-install@v1
+      - run: npm ci
       - run: npm run test
         env:
           CI: true


### PR DESCRIPTION
## Description

- Add `cache` to workflows using `actions/setup-node`
- Replaces `bahmutov/npm-install` by `npm ci`. Now this GitHub Action is not necessary. Context: 
   - https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action/issues/13 and
   - https://github.com/probot/settings/issues/472#event-4979789613)

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
