### PR TITLE
fix: ts compilerOptions cannot be generated correctly

### DIFF
--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -120,7 +120,7 @@ const transformer: Transformer<Options.Typescript> = ({
   Object.assign(compilerOptionsJSON, options.compilerOptions);
 
   const { errors, options: convertedCompilerOptions } =
-    options.tsconfigFile !== false || options.tsconfigDirectory
+    options.tsconfigFile || options.tsconfigDirectory
       ? loadTsconfig(compilerOptionsJSON, filename, options)
       : ts.convertCompilerOptionsFromJson(compilerOptionsJSON, basePath);
 


### PR DESCRIPTION
`options.tsconfigFile` is optional and has no default value.
When tsconfigFile is undefiend, compilerOptions cannot be generated correctly.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [ ] Run the tests with `npm test` or `yarn test`
