### PR TITLE
(fix) relax TS peer dep requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "stylus": "^0.54.7",
     "sugarss": "^2.0.0",
     "svelte": "^3.23.0",
-    "typescript": "^4.4.2"
+    "typescript": "^3.9.5 || ^4.0.0"
   },
   "peerDependenciesMeta": {
     "@babel/core": {


### PR DESCRIPTION
Reverts part of #395

I don't know why the peer dependency was bumped, I don't think it was necessary and it's a breaking change, so we should revert it

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [ ] Run the tests with `npm test` or `yarn test`
