### PR TITLE
(fix) Clear outDir if set in tsconfig

### DIFF
--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -253,6 +253,8 @@ function getCompilerOptions({
   const compilerOptionsJSON = {
     moduleResolution: 'node',
     target: 'es6',
+    // Clear outDir since it causes source map issues when the files aren't actually written to disk.
+    outDir: undefined,
   };
 
   Object.assign(compilerOptionsJSON, options.compilerOptions);

--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -253,8 +253,6 @@ function getCompilerOptions({
   const compilerOptionsJSON = {
     moduleResolution: 'node',
     target: 'es6',
-    // Clear outDir since it causes source map issues when the files aren't actually written to disk.
-    outDir: undefined,
   };
 
   Object.assign(compilerOptionsJSON, options.compilerOptions);
@@ -272,6 +270,8 @@ function getCompilerOptions({
     ...(convertedCompilerOptions as CompilerOptions),
     importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Error,
     allowNonTsExtensions: true,
+    // Clear outDir since it causes source map issues when the files aren't actually written to disk.
+    outDir: undefined,
   };
 
   if (

--- a/test/fixtures/tsconfig.outdir.json
+++ b/test/fixtures/tsconfig.outdir.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "es2015",
+    "skipLibCheck": true,
+    "outDir": "dist"
+  }
+}

--- a/test/transformers/typescript.test.ts
+++ b/test/transformers/typescript.test.ts
@@ -177,6 +177,20 @@ describe('transformer - typescript', () => {
       expect(map).toHaveProperty('sources', ['App.svelte']);
     });
 
+    it('should work when tsconfig contains outDir', async () => {
+      const opts = sveltePreprocess({
+        typescript: {
+          tsconfigFile: './test/fixtures/tsconfig.outdir.json',
+          handleMixedImports: true,
+        },
+        sourceMap: true,
+      });
+
+      const preprocessed = await preprocess(template, opts);
+
+      expect(preprocessed.toString?.()).toContain(EXPECTED_SCRIPT);
+    });
+
     it('supports extends field', () => {
       const { options } = loadTsconfig({}, getTestAppFilename(), {
         tsconfigFile: './test/fixtures/tsconfig.extends1.json',


### PR DESCRIPTION
As mentioned in #405. Since it's a quick fix I decided to just submit the PR before any discussion. Happy to discuss more if you're not sure if this is the right thing to do.

If outDir is set, Typescript sets directories in the source maps relative to it
which causes problems in `concatSourceMaps` when the paths in the source
point to nonexistent files instead of the virtual modules set up by the
transformer.

Tested against https://github.com/dimfeld/svelte-preprocess-injected-bug and also added a new unit test.

Fixes #405

