### PR TITLE
(fix) return default settings when no tsconfig found

### DIFF
--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -351,7 +351,7 @@ export function loadTsconfig(
     ts.findConfigFile(fileDirectory, ts.sys.fileExists);
 
   if (!tsconfigFile) {
-    return { errors: [], options: {} };
+    return { errors: [], options: compilerOptionsJSON };
   }
 
   tsconfigFile = isAbsolute(tsconfigFile)


### PR DESCRIPTION
This prevents the code from being transpiled as es3 in this situation, which makes the `const $$$$$ = ..` separator get transformed into `var $$$$$ = ...` which then is no longer split out. This situation came up in the tests of `svelte-jester`.
No test added, because it's not really possible, because there's a tsconfig in this repo which would be found.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [x] Run the tests with `npm test` or `yarn test`
