### PR TITLE
Don't overwrite `target` settings from tsconfig.json

### DIFF
--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -249,24 +249,20 @@ function getCompilerOptions({
   options: Options.Typescript;
   basePath: string;
 }): CompilerOptions {
-  // default options
-  const compilerOptionsJSON = {
-    moduleResolution: 'node',
-    target: 'es6',
-  };
-
-  Object.assign(compilerOptionsJSON, options.compilerOptions);
+  const inputOptions = options.compilerOptions ?? {};
 
   const { errors, options: convertedCompilerOptions } =
     options.tsconfigFile !== false || options.tsconfigDirectory
-      ? loadTsconfig(compilerOptionsJSON, filename, options)
-      : ts.convertCompilerOptionsFromJson(compilerOptionsJSON, basePath);
+      ? loadTsconfig(inputOptions, filename, options)
+      : ts.convertCompilerOptionsFromJson(inputOptions, basePath);
 
   if (errors.length) {
     throw new Error(formatDiagnostics(errors, basePath));
   }
 
   const compilerOptions: CompilerOptions = {
+    target: ts.ScriptTarget.ES2015,
+    moduleResolution: ts.ModuleResolutionKind.NodeJs,
     ...(convertedCompilerOptions as CompilerOptions),
     importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Error,
     allowNonTsExtensions: true,

--- a/test/fixtures/TypeScriptES2021.svelte
+++ b/test/fixtures/TypeScriptES2021.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  let x = true;
+  x &&= false;
+  x ||= true;
+
+  async function doIt() {
+    await (() => true)();
+  }
+</script>

--- a/test/fixtures/tsconfig.es2021target.json
+++ b/test/fixtures/tsconfig.es2021target.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "skipLibCheck": true
+  }
+}

--- a/test/transformers/typescript.test.ts
+++ b/test/transformers/typescript.test.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'path';
 
+import { compile } from 'svelte/compiler';
 import type { Diagnostic } from 'typescript';
 
 import sveltePreprocess from '../../src';
@@ -187,6 +188,43 @@ describe('transformer - typescript', () => {
         skipLibCheck: false,
         esModuleInterop: true,
       });
+    });
+
+    it('should not override the target setting if one is present', async () => {
+      const tpl = getFixtureContent('TypeScriptES2021.svelte');
+
+      const opts = sveltePreprocess({
+        typescript: {
+          tsconfigFile: './test/fixtures/tsconfig.es2021target.json',
+        },
+      });
+
+      const { code } = await preprocess(tpl, opts);
+
+      expect(code).toContain('await ');
+      expect(code).toContain('async function doIt');
+      expect(code).toContain('&&=');
+      expect(code).toContain('||=');
+
+      // Svelte should be able to compile ES2021.
+      const { warnings } = compile(code, { name: 'Test' });
+
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('should target ES6 if the configuration has no target setting', async () => {
+      const tpl = getFixtureContent('TypeScriptES2021.svelte');
+
+      const opts = sveltePreprocess({
+        typescript: { tsconfigFile: false },
+      });
+
+      const { code } = await preprocess(tpl, opts);
+
+      expect(code).not.toContain('await ');
+      expect(code).not.toContain('async function doIt');
+      expect(code).not.toContain('&&=');
+      expect(code).not.toContain('||=');
     });
   });
 });


### PR DESCRIPTION
Resolves #383.

I moved all of the default options down to line 269, since the current behavior gave unusual precedence to the defaults where they would override options from tsconfig, but not options directly passed to the preprocessor, which feels unintuitive. I can move the `moduleResolution` setting back though, if you disagree.

~~This could be considered semver-major, since moving the default target to ES2021 would cause problems if anyone was inadvertently relying on ES6 transpilation to demodernize their JS and didn't have a proper Babel step or something in the bundler.~~