### PR TITLE
fix: coffeescript sourcemap

### DIFF
--- a/src/transformers/coffeescript.ts
+++ b/src/transformers/coffeescript.ts
@@ -17,10 +17,12 @@ const transformer: Transformer<Options.Coffeescript> = ({
   } as Omit<Options.Coffeescript, 'bare'>;
 
   if (coffeeOptions.sourceMap) {
-    const { js: code, sourceMap: map } = coffeescript.compile(
+    const { js: code, v3SourceMap } = coffeescript.compile(
       content,
       coffeeOptions,
     );
+
+    const map = JSON.parse(v3SourceMap);
 
     return { code, map };
   }


### PR DESCRIPTION
Fixes #413

The coffeescript transformer was using an old sourcemap format I believe. It was something like:

```
SourceMap {
  lines: [
    LineMap { line: 0, columns: [Array] },
    <1 empty item>,
    LineMap { line: 2, columns: [Array] }
  ]
}
```

This change uses the `v3SourceMap` string from the compile result instead.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [x] Run the tests with `npm test` or `yarn test`
