### PR TITLE
fix: generate high resolution source map

### DIFF
--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -167,15 +167,13 @@ function injectVarsToCode({
       : `${sep}${getScriptContent(markup, true)}\n${injectedVars}`;
 
   if (sourceMapChain) {
-    const s = new MagicString(content);
-
-    s.append(injectedCode);
-
+    const ms = new MagicString(content).append(injectedCode);
     const fname = `${filename}.injected.ts`;
-    const code = s.toString();
-    const map = s.generateMap({
+    const code = ms.toString();
+    const map = ms.generateMap({
       source: filename,
       file: fname,
+      hires: true,
     });
 
     sourceMapChain.content[fname] = code;
@@ -203,15 +201,14 @@ function stripInjectedCode({
   const injectedCodeStart = transpiledCode.indexOf(injectedCodeSeparator);
 
   if (sourceMapChain) {
-    const s = new MagicString(transpiledCode);
-    const st = s.snip(0, injectedCodeStart);
-
+    const ms = new MagicString(transpiledCode).snip(0, injectedCodeStart);
     const source = `${filename}.transpiled.js`;
     const file = `${filename}.js`;
-    const code = st.toString();
-    const map = st.generateMap({
+    const code = ms.toString();
+    const map = ms.generateMap({
       source,
       file,
+      hires: true,
     });
 
     sourceMapChain.content[file] = code;


### PR DESCRIPTION
When using the advanced import preprocessor, make sure to use a high resolution source map.
Else the mappings won't be that good anymore (line mappings at best).

Maybe related to #421

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [x] Run the tests with `npm test` or `yarn test`
