### PR TITLE
feat(babel): provide caller information to Babel

### DIFF
--- a/src/transformers/babel.ts
+++ b/src/transformers/babel.ts
@@ -26,7 +26,7 @@ const transformer: Transformer<Options.Babel> = async ({
       supportsDynamicImport: true,
       // this isn't supported by Svelte but let it error with a good error on this syntax untouched
       supportsTopLevelAwait: true,
-      // this can be enabled once all "peer deps" understand this
+      // todo: this can be enabled once all "peer deps" understand this
       // this syntax is supported since rollup@1.26.0 and webpack@5.0.0-beta.21
       // supportsExportNamespaceFrom: true,
       ...options?.caller,

--- a/src/transformers/babel.ts
+++ b/src/transformers/babel.ts
@@ -24,6 +24,7 @@ const transformer: Transformer<Options.Babel> = async ({
       name: 'svelte-preprocess',
       supportsStaticESM: true,
       supportsDynamicImport: true,
+      // this isn't supported by Svelte but let it error with a good error on this syntax untouched
       supportsTopLevelAwait: true,
       // this can be enabled once all "peer deps" understand this
       // this syntax is supported since rollup@1.26.0 and webpack@5.0.0-beta.21

--- a/src/transformers/babel.ts
+++ b/src/transformers/babel.ts
@@ -20,6 +20,14 @@ const transformer: Transformer<Options.Babel> = async ({
     minified: false,
     ast: false,
     code: true,
+    caller: {
+      name: 'svelte-preprocess',
+      supportsStaticESM: true,
+      supportsDynamicImport: true,
+      supportsTopLevelAwait: true,
+      supportsExportNamespaceFrom: true,
+      ...options?.caller,
+    },
   } as TransformOptions;
 
   const result = await transformAsync(content, babelOptions);

--- a/src/transformers/babel.ts
+++ b/src/transformers/babel.ts
@@ -25,7 +25,9 @@ const transformer: Transformer<Options.Babel> = async ({
       supportsStaticESM: true,
       supportsDynamicImport: true,
       supportsTopLevelAwait: true,
-      supportsExportNamespaceFrom: true,
+      // this can be enabled once all "peer deps" understand this
+      // this syntax is supported since rollup@1.26.0 and webpack@5.0.0-beta.21
+      // supportsExportNamespaceFrom: true,
       ...options?.caller,
     },
   } as TransformOptions;

--- a/test/transformers/babel.test.ts
+++ b/test/transformers/babel.test.ts
@@ -40,4 +40,37 @@ $: bar = foo?.b ?? 120
       $: bar = (_foo$b = foo == null ? void 0 : foo.b) != null ? _foo$b : 120;</script>"
     `);
   });
+
+  it('should not transpile modules with preset-env', async () => {
+    const template = `<script>
+import foo from './foo'
+$: bar = foo?.b ?? 120
+</script>`;
+
+    const opts = sveltePreprocess({
+      babel: {
+        presets: [
+          [
+            '@babel/preset-env',
+            {
+              loose: true,
+              targets: {
+                esmodules: true,
+              },
+            },
+          ],
+        ],
+      },
+    });
+
+    const preprocessed = await preprocess(template, opts);
+
+    expect(preprocessed.code).toMatchInlineSnapshot(`
+      "<script>var _foo$b;
+
+      import foo from './foo';
+
+      $: bar = (_foo$b = foo == null ? void 0 : foo.b) != null ? _foo$b : 120;</script>"
+    `);
+  });
 });

--- a/test/transformers/babel.test.ts
+++ b/test/transformers/babel.test.ts
@@ -41,7 +41,7 @@ $: bar = foo?.b ?? 120
     `);
   });
 
-  it('should not transpile modules with preset-env', async () => {
+  it('should not transpile import/export syntax with preset-env', async () => {
     const template = `<script>
 import foo from './foo'
 $: bar = foo?.b ?? 120


### PR DESCRIPTION
This PR provides `options.caller` to Babel when transforming files, it's what `@rollup/plugin-babel` does [here](https://github.com/rollup/plugins/blob/8c6ae32f96ab299ca0b1207857e242bac89b9ca7/packages/babel/src/index.js#L62-L69) and what webpack's `babel-loader` does [here](https://github.com/babel/babel-loader/blob/eafd20d4877497f6c504a37611c2430e38446a7c/src/injectCaller.js#L7-L23)

When this is configured on the caller's side (`svelte-preprocess` in this scenario) then `@babel/preset-env` won't touch certain language features by default - they will still be transpiled if there is an explicit configuration to do so.

This allows for people to maintain a single Babel config where each tool can opt-out of certain transforms. For instance, with the config used in the added test modules would be transpiled to CJS when running in Jest but they will be preserved when transpiling through `svelte-preprocess` so Svelte's compiler will see them, instead of CJS's `require`.

### Tests

- [x] Run the tests with `npm test` or `yarn test`
