### PR TITLE
[sass] Tell, that we use legacy api

### DIFF
--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -354,7 +354,7 @@ The `scss/sass` preprocessor accepts the default sass options alongside two othe
 | `renderSync`     | `false`     | if `true`, use the sync render method which is faster for dart sass.                                                           |
 | `implementation` | `undefined` | pass the module to use to compile sass, if unspecified, `svelte-preprocess` will first look for `node-sass` and then for Sass. |
 
-You can check the [Sass API reference](https://sass-lang.com/documentation/js-api) for specific Sass options. The `file` and `data` properties are not supported. Instead, use the `prependData` property if you want to prepend some content to your `scss` content.
+You can check the [Sass Legacy API reference](https://sass-lang.com/documentation/js-api#legacy-api) for specific Sass options. The `file` and `data` properties are not supported. Instead, use the `prependData` property if you want to prepend some content to your `scss` content.
 
 Note: `svelte-preprocess` automatically configures inclusion paths for your root directory, `node_modules` and for the current file's directory.
 

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,5 +1,5 @@
 import type * as postcss from 'postcss';
-import type { Options as SassOptions, render, renderSync } from 'sass';
+import type { LegacyOptions as SassOptions, render, renderSync } from 'sass';
 import type { Options as PugOptions } from 'pug';
 import type { TransformOptions as BabelOptions } from '@babel/core';
 


### PR DESCRIPTION
Partial-fix #452 

This patch only fixes the most pressing problem.

There is a question of how to deal with libraries that use legacy importers. 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [ ] Run the tests with `npm test` or `yarn test`
