### PR TITLE
fix: ts preprocessor to consider store suffixed with number

### DIFF
--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -152,7 +152,7 @@ function injectVarsToCode({
   // TODO investigate if it's possible to achieve this with a
   // TS transformer (previous attemps have failed)
   const codestores = Array.from(
-    contentForCodestores.match(/\$[^\s();:,[\]{}.?!+-=*/\\~|&%<>^`"'°§]+/g) ||
+    contentForCodestores.match(/\$[^\s();:,[\]{}.?!+\-=*/\\~|&%<>^`"'°§]+/g) ||
       [],
     (name) => name.slice(1),
   ).filter((name) => !JAVASCRIPT_RESERVED_KEYWORD_SET.has(name));

--- a/test/fixtures/TypeScriptImports.svelte
+++ b/test/fixtures/TypeScriptImports.svelte
@@ -10,7 +10,7 @@
     import Nested from "./Nested.svelte";
     import { hello } from "./script";
     import { AValue, AType } from "./types";
-    import { storeTemplateOnly, storeScriptOnly } from "./store";
+    import { storeTemplateOnly, storeScriptOnly, store0 } from "./store";
     import { onlyUsedInModuleScript } from "./modulescript";
     const ui = { MyNested: Nested };
     const val: AType = "test1";
@@ -39,6 +39,7 @@
     }
     $storeScriptOnly;
     $storeModuleScriptOnly;
+    $store0;
 
     // These shouldn't count as store values:
     // $\\; $$; $§; $%; $°; $(; $); $[; $]; $<; $>; $ ; $^; $`; $"; $';

--- a/test/transformers/typescript.test.ts
+++ b/test/transformers/typescript.test.ts
@@ -129,7 +129,7 @@ describe('transformer - typescript', () => {
       expect(code).toContain(`import { hello } from "./script"`);
       expect(code).toContain(`import { AValue } from "./types"`);
       expect(code).toContain(
-        `import { storeTemplateOnly, storeScriptOnly } from "./store"`,
+        `import { storeTemplateOnly, storeScriptOnly, store0 } from "./store"`,
       );
       expect(code).toContain(
         `import { onlyUsedInModuleScript } from "./modulescript";`,


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/7120

the original regex had `+-=`, which forgot to escape `-`, resulting ignoring any characters between `+` to `=`

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [x] Run the tests with `npm test` or `yarn test`
