### PR TITLE
fix: add # and numbers to ts store regex

### DIFF
--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -153,7 +153,7 @@ function injectVarsToCode({
   // TS transformer (previous attemps have failed)
   const codestores = Array.from(
     contentForCodestores.match(
-      /\$[^\s();:,[\]{}.?!+\-=*/\\~|&%<>^`"'°§#1-9][^\s();:,[\]{}.?!+\-=*/\\~|&%<>^`"'°§#]*/g,
+      /\$[^\s();:,[\]{}.?!+\-=*/\\~|&%<>^`"'°§#0-9][^\s();:,[\]{}.?!+\-=*/\\~|&%<>^`"'°§#]*/g,
     ) || [],
     (name) => name.slice(1),
   ).filter((name) => !JAVASCRIPT_RESERVED_KEYWORD_SET.has(name));

--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -152,9 +152,7 @@ function injectVarsToCode({
   // TODO investigate if it's possible to achieve this with a
   // TS transformer (previous attemps have failed)
   const codestores = Array.from(
-    contentForCodestores.match(
-      /\$[^\s();:,[\]{}.?!+\-=*/\\~|&%<>^`"'°§#1-9]+/g,
-    ) || [],
+    contentForCodestores.match(/\$[a-zA-Z_][\w_$]*/g) || [],
     (name) => name.slice(1),
   ).filter((name) => !JAVASCRIPT_RESERVED_KEYWORD_SET.has(name));
 

--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -152,8 +152,9 @@ function injectVarsToCode({
   // TODO investigate if it's possible to achieve this with a
   // TS transformer (previous attemps have failed)
   const codestores = Array.from(
-    contentForCodestores.match(/\$[^\s();:,[\]{}.?!+\-=*/\\~|&%<>^`"'°§]+/g) ||
-      [],
+    contentForCodestores.match(
+      /\$[^\s();:,[\]{}.?!+\-=*/\\~|&%<>^`"'°§#1-9]+/g,
+    ) || [],
     (name) => name.slice(1),
   ).filter((name) => !JAVASCRIPT_RESERVED_KEYWORD_SET.has(name));
 

--- a/src/transformers/typescript.ts
+++ b/src/transformers/typescript.ts
@@ -152,7 +152,9 @@ function injectVarsToCode({
   // TODO investigate if it's possible to achieve this with a
   // TS transformer (previous attemps have failed)
   const codestores = Array.from(
-    contentForCodestores.match(/\$[a-zA-Z_][\w_$]*/g) || [],
+    contentForCodestores.match(
+      /\$[^\s();:,[\]{}.?!+\-=*/\\~|&%<>^`"'°§#1-9][^\s();:,[\]{}.?!+\-=*/\\~|&%<>^`"'°§#]*/g,
+    ) || [],
     (name) => name.slice(1),
   ).filter((name) => !JAVASCRIPT_RESERVED_KEYWORD_SET.has(name));
 

--- a/test/fixtures/TypeScriptImports.svelte
+++ b/test/fixtures/TypeScriptImports.svelte
@@ -23,7 +23,13 @@
         $in: "",
         a: "$",
         b: '$',
-        c: `$`
+        c: `$`,
+        d: "$#",
+        e: '$#',
+        f: `$#`,
+        g: "$1a",
+        h: '$2b',
+        i: `$3c`
     };
     let inputVal: string;
     const action = (node: Element, options: { id: string; }) => { node.id = options.id; };


### PR DESCRIPTION
Fixes #466

And also fixes another situation that led me to research this issue. Where something like this

```ts
let str = "$1$2";
```
or

```ts
let str = "$1a";
```
would result in a type error (TS1351) where it was assuming that `1$2` was a variable where it should not

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [x] Run the tests with `npm test` or `yarn test`
