### PR TITLE
fix: @font-face inside :global block

### DIFF
--- a/src/transformers/globalStyle.ts
+++ b/src/transformers/globalStyle.ts
@@ -23,7 +23,11 @@ const globalifyRulePlugin = (root: pcss.Root) => {
       });
 
     if (modifiedSelectors.length === 0) {
-      rule.remove();
+      if (rule.parent?.type === 'atrule' && rule.selector === ':global') {
+        rule.replaceWith(...rule.nodes);
+      } else {
+        rule.remove();
+      }
 
       return;
     }

--- a/test/transformers/globalStyle.test.ts
+++ b/test/transformers/globalStyle.test.ts
@@ -251,5 +251,14 @@ describe('transformer - globalStyle', () => {
         '<style>div{/*comment*/}</style>',
       );
     });
+    it('unwraps :global in @font-face', async () => {
+      const template = `<style>@font-face{:global{font-family:Helvetica}}</style>`;
+      const opts = autoProcess();
+      const preprocessed = await preprocess(template, opts);
+
+      expect(preprocessed.toString?.()).toContain(
+        '<style>@font-face{font-family:Helvetica}</style>',
+      );
+    });
   });
 });


### PR DESCRIPTION
Fixes #236

```svelte
<style lang="scss">
:global {
  @font-face {
    font-family: "Open Sans";
    src: url("/fonts/OpenSans-Regular.woff2") format("woff2"),
  }
}
</style>
```
Currently generates:
```css
@font-face {}
```
Instead of the desired:
```css
@font-face {
  font-family: "Open Sans";
  src: url("/fonts/OpenSans-Regular.woff2") format("woff2"),
}
```

"you shouldn't need to use `:global` for `@font-face`" was the reason for closing #236 
And while this is an ok solution for when the `@font-face` is written inside the svelte component, I've encountered this issue when using the following pattern from the Readme:

```svelte
<style lang="scss">
  :global {
    @import 'global-stylesheet.scss';
  }
}
```
All the `@font-face` rules in global-stylesheet.scss are currently being emptied by svelte-preprocess.
This PR fixes that
