### PR TITLE
fix: only try to load external files with relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ _Vue-like_ support for defining your markup between a specific tag. The default 
 <style src="./style.css"></style>
 ```
 
+> Note: using a relative path starting with `.` is important. Otherwise `svelte-preprocess` will ignore the `src` attribute.
+
 ### Global style
 
 #### `global` attribute

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -60,15 +60,8 @@ export async function hasDepInstalled(dep: string) {
   return (depCheckCache[dep] = result);
 }
 
-const REMOTE_SRC_PATTERN = /^(https?:)?\/\//;
-
 export function isValidLocalPath(path: string) {
-  return (
-    path.match(REMOTE_SRC_PATTERN) == null &&
-    // only literal strings allowed
-    !path.startsWith('{') &&
-    !path.endsWith('}')
-  );
+  return path.startsWith('.') && !path.startsWith('{') && !path.endsWith('}');
 }
 
 // finds a existing path up the tree

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -61,7 +61,7 @@ export async function hasDepInstalled(dep: string) {
 }
 
 export function isValidLocalPath(path: string) {
-  return path.startsWith('.') && !path.startsWith('{') && !path.endsWith('}');
+  return path.startsWith('.');
 }
 
 // finds a existing path up the tree


### PR DESCRIPTION
Closes https://github.com/sveltejs/kit/issues/4062

The `isValidLocalPath` was checking the path validity the other way around (not remote). We should instead check if it's a valid local path (starts with `.` and doesn't contain interpolation).