### PR TITLE
fix: stylus relative sourcemap sources

### DIFF
--- a/src/transformers/stylus.ts
+++ b/src/transformers/stylus.ts
@@ -4,7 +4,12 @@ import stylus from 'stylus';
 
 import { getIncludePaths } from '../modules/utils';
 
+import type { SourceMap } from 'magic-string';
 import type { Transformer, Options } from '../types';
+
+type StylusRendererWithSourceMap = ReturnType<typeof stylus> & {
+  sourcemap: SourceMap;
+};
 
 const transformer: Transformer<Options.Stylus> = ({
   content,
@@ -20,15 +25,16 @@ const transformer: Transformer<Options.Stylus> = ({
     const style = stylus(content, {
       filename,
       ...options,
-    }).set('sourcemap', options.sourcemap);
+    }).set('sourcemap', options.sourcemap) as StylusRendererWithSourceMap;
 
     style.render((err, css) => {
       // istanbul ignore next
       if (err) reject(err);
+      const map = style.sourcemap.sources.map((source) => path.resolve(source));
 
       resolve({
         code: css,
-        map: (style as any).sourcemap,
+        map,
         // .map() necessary for windows compatibility
         dependencies: style
           .deps(filename as string)

--- a/src/transformers/stylus.ts
+++ b/src/transformers/stylus.ts
@@ -30,11 +30,15 @@ const transformer: Transformer<Options.Stylus> = ({
     style.render((err, css) => {
       // istanbul ignore next
       if (err) reject(err);
-      const map = style.sourcemap.sources.map((source) => path.resolve(source));
+      if (style.sourcemap?.sources) {
+        style.sourcemap.sources = style.sourcemap.sources.map((source) =>
+          path.resolve(source),
+        );
+      }
 
       resolve({
         code: css,
-        map,
+        map: style.sourcemap,
         // .map() necessary for windows compatibility
         dependencies: style
           .deps(filename as string)


### PR DESCRIPTION
The stylus preprocessor didn't resolve fully sourcemap dependencies, which could cause bugs when using Stylus as preprocessor with Svelte.

https://github.com/sveltejs/svelte-preprocess/pull/500#issuecomment-1119410260