### PR TITLE
Fix link to preprocess API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ## What is it?
 
-`Svelte`'s own parser understands only JavaScript, CSS and its HTML-like syntax. To make it possible to write components in other languages, such as TypeScript or SCSS, `Svelte` provides the [preprocess API](https://svelte.dev/docs#svelte_preprocess), which allows to easily transform the content of your `markup` and your `style`/`script` tags.
+`Svelte`'s own parser understands only JavaScript, CSS and its HTML-like syntax. To make it possible to write components in other languages, such as TypeScript or SCSS, `Svelte` provides the [preprocess API](https://svelte.dev/docs#compile-time-svelte-preprocess), which allows to easily transform the content of your `markup` and your `style`/`script` tags.
 
 Writing your own preprocessor for, i.e SCSS is easy enough, but it can be cumbersome to have to always configure multiple preprocessors for the languages you'll be using.
 


### PR DESCRIPTION
I think the URL for the preprocess API docs changed at some point. Clicking it takes me to the top of the docs page. I've replaced it with what I believe to be the correct URL.

Apologies for not creating an issue for this, it didn't strike me as providing value for such a small change.