### PR TITLE
docs(updated link to compiler options for scss & sass)

### DIFF
--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -356,7 +356,7 @@ The `scss/sass` preprocessor accepts the default sass options alongside two othe
 | `renderSync`     | `false`     | if `true`, use the sync render method which is faster for dart sass.                                                           |
 | `implementation` | `undefined` | pass the module to use to compile sass, if unspecified, `svelte-preprocess` will first look for `node-sass` and then for Sass. |
 
-You can check the [Sass API reference](https://sass-lang.com/documentation/js-api) for specific Sass options. The `file` and `data` properties are not supported. Instead, use the `prependData` property if you want to prepend some content to your `scss` content.
+You can check the [Sass API reference](https://sass-lang.com/documentation/js-api/modules#LegacyOptions) for specific Sass options. The `file` and `data` properties are not supported. Instead, use the `prependData` property if you want to prepend some content to your `scss` content.
 
 Note: `svelte-preprocess` automatically configures inclusion paths for your root directory, `node_modules` and for the current file's directory.
 


### PR DESCRIPTION
hint for where to find additional sass / scss compiler options.

this was very confusing for me, since the docs suggest that you can pass **importers** to the sass preprocessor and gave a different type definition from what svelte-preprocess expects.

taking the following code snippet from the [current sass docs](https://sass-lang.com/documentation/js-api/interfaces/FileImporter) does not work:
```javascript
preprocess({
  scss: {
    importers: [{
      // An importer that redirects relative URLs starting with "~" to
      // `node_modules`.
      findFileUrl(url) {
        if (!url.startsWith('~')) return null;
        return new URL(url.substring(1), pathToFileURL('node_modules'));
      }
    }]
  }
})
```

while something like this would:
```javascript
preprocess({
  scss: {
    importer: (url) => {
      console.log(url)

      return {
        file: url
      }
    }]
  }
})
```

i hope this is only a temporary fix for when svelte-preprocess moves to a newer sass version