### PR TITLE
docs: Update documentation about Sass options

### DIFF
--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -349,12 +349,9 @@ input(on:input="{bar}")
 
 ### scss, sass
 
-The `scss/sass` preprocessor accepts the default sass options alongside two other props:
+The `scss/sass` preprocessor accepts the options listed in the [Sass `LegacyStringOptions` API reference](https://sass-lang.com/documentation/js-api/interfaces/LegacyStringOptions) with some exceptions: the `file` and `data` properties are not supported. Instead, use the `prependData` property if you want to prepend some content to your `scss` content.
 
-| Option           | Default     | Description                                                                                                                    |
-| ---------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `renderSync`     | `false`     | if `true`, use the sync render method which is faster for dart sass.                                                           |
-You can check the [Sass Legacy API reference](https://sass-lang.com/documentation/js-api#legacy-api) for specific Sass options. The `file` and `data` properties are not supported. Instead, use the `prependData` property if you want to prepend some content to your `scss` content.
+Note: `svelte-preprocess` (version 5.0.0 and later) always uses [Sass's legacy `renderSync` API](https://sass-lang.com/documentation/js-api/#legacy-api).
 
 Note: `svelte-preprocess` automatically configures inclusion paths for your root directory, `node_modules` and for the current file's directory.
 


### PR DESCRIPTION
Fixes #563: The doc had incorrect/outdated information about the `renderSync` option). The update notes that `renderSync` is always used as of svelte-preprocess 5.0.0.

While addressing this, I also added a more specific cross reference link for users to see which options can be passed: https://sass-lang.com/documentation/js-api/interfaces/LegacyStringOptions

I also removed the table, since that formatting now longer seemed useful, and made other minor wording adjustments to this section.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to run `pnpm lint`!)

### Tests

- [x] Run the tests with `npm test` or `pnpm test`
