### PR TITLE
fix: remove deprecated package @types/sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
   },
   "dependencies": {
     "@types/pug": "^2.0.6",
-    "@types/sass": "^1.43.1",
     "detect-indent": "^6.1.0",
     "magic-string": "^0.27.0",
     "sorcery": "^0.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,6 @@ specifiers:
   '@types/jest': ^27.5.2
   '@types/node': ^14.18.34
   '@types/pug': ^2.0.6
-  '@types/sass': ^1.43.1
   '@types/stylus': ^0.48.38
   autoprefixer: ^9.8.8
   babel-minify: ^0.5.2
@@ -40,7 +39,6 @@ specifiers:
 
 dependencies:
   '@types/pug': 2.0.6
-  '@types/sass': 1.43.1
   detect-indent: 6.1.0
   magic-string: 0.27.0
   sorcery: 0.11.0
@@ -1857,6 +1855,7 @@ packages:
 
   /@types/node/14.18.34:
     resolution: {integrity: sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA==}
+    dev: true
 
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -1872,12 +1871,6 @@ packages:
 
   /@types/pug/2.0.6:
     resolution: {integrity: sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==}
-    dev: false
-
-  /@types/sass/1.43.1:
-    resolution: {integrity: sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==}
-    dependencies:
-      '@types/node': 14.18.34
     dev: false
 
   /@types/semver/7.3.13:


### PR DESCRIPTION
Fixes #582.

My best guess is that `@types/sass` was included in `dependencies` (and not `devDependencies`) as a convenience for users. With types now being included in the main `sass` package, it should no longer be an issue that people might have `sass` without the types, so we can safely remove the types here without promoting `sass` from `devDependencies` to `dependencies`. 

This removes the warning described in #582.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to run `pnpm lint`!)

### Tests

- [x] Run the tests with `npm test` or `pnpm test`
