### PR TITLE
fix: spell. "identation" → "indentation "

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -520,7 +520,7 @@
 
 ### Bug Fixes
 
-- remove extra identation for sass content ([7d0f437](https://github.com/kaisermann/svelte-preprocess/commit/7d0f4376037d1ff6b426e2d6882adb6b08d95464))
+- remove extra indentation for sass content ([7d0f437](https://github.com/kaisermann/svelte-preprocess/commit/7d0f4376037d1ff6b426e2d6882adb6b08d95464))
 
 ## [3.9.9](https://github.com/kaisermann/svelte-preprocess/compare/v3.9.7...v3.9.9) (2020-06-19)
 

--- a/src/transformers/pug.ts
+++ b/src/transformers/pug.ts
@@ -4,7 +4,7 @@ import pug from 'pug';
 import type { Transformer, Options } from '../types';
 
 // Mixins to use svelte template features
-const GET_MIXINS = (identationType: 'tab' | 'space') =>
+const GET_MIXINS = (indentationType: 'tab' | 'space') =>
   `mixin if(condition)
 %_| {#if !{condition}}
 %_block
@@ -50,7 +50,7 @@ mixin const(expression)
 mixin debug(variables)
 %_| {@debug !{variables}}`.replace(
     /%_/g,
-    identationType === 'tab' ? '\t' : '  ',
+    indentationType === 'tab' ? '\t' : '  ',
   );
 
 const transformer: Transformer<Options.Pug> = async ({
@@ -67,8 +67,8 @@ const transformer: Transformer<Options.Pug> = async ({
     ...options,
   };
 
-  const { type: identationType } = detectIndent(content);
-  const input = `${GET_MIXINS(identationType ?? 'space')}\n${content}`;
+  const { type: indentationType } = detectIndent(content);
+  const input = `${GET_MIXINS(indentationType ?? 'space')}\n${content}`;
   const compiled = pug.compile(
     input,
     pugOptions,


### PR DESCRIPTION
*I am Japanese and not good at English, so I am translating at DeepL.

I am afraid this is a minor thing, but I found a spelling mistake and corrected it. ("identation" corrected to "indentation").
If this is my mistake, please close this PR.

### Tests

- [x] Run the tests with `npm test` or `pnpm test`
