### PR TITLE
fix: spelling "dianostics" - "diagnostics"

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,7 +20,7 @@ export type TransformerArgs<T> = {
   attributes?: Record<string, any>;
   map?: string | object;
   markup?: string;
-  dianostics?: unknown[];
+  diagnostics?: unknown[];
   options?: T;
 };
 


### PR DESCRIPTION
Spelling fix on a type.

### Tests

- [x] Run the tests with `npm test` or `pnpm test` (passed)
