### PR TITLE
fix: sass dependency list referencing source file in win32

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "packageManager": "pnpm@8.12.1",
   "volta": {
-    "node": "14.19.2"
+    "node": "20.10.0"
   },
   "files": [
     "dist/"


### PR DESCRIPTION
Should close #619

Argh, just remembered that this is hard to reproduce in tests for some reason: https://github.com/sveltejs/svelte-preprocess/blob/main/src/transformers/scss.ts#L72