### PR TITLE
fix: Adjust globalifySelector to not split selectors with parentheses.

### DIFF
--- a/src/modules/globalifySelector.ts
+++ b/src/modules/globalifySelector.ts
@@ -6,7 +6,7 @@
  * escaped combinators like `\~`.
  */
 // TODO: maybe replace this ugly pattern with an actual selector parser? (https://github.com/leaverou/parsel, 2kb)
-const combinatorPattern = /(?<!\\)(?:\\\\)*([ >+~,]\s*)(?![^[]+\]|\d)/g;
+const combinatorPattern = /(?<!\\)(?:\\\\)*([ >+~,]\s*)(?![^(]*\))(?![^[]+\]|\d)/g;
 
 export function globalifySelector(selector: string) {
   const parts = selector.trim().split(combinatorPattern);

--- a/test/modules/globalifySelector.test.ts
+++ b/test/modules/globalifySelector.test.ts
@@ -57,4 +57,10 @@ describe('globalifySelector', () => {
       `:global(p:nth-child(n+8):nth-child(-n+15))`,
     );
   });
+
+  it('works with selector with whitespace in parenthesis: :is()', async () => {
+    expect(globalifySelector('article :is(h1, h2)')).toBe(
+      `:global(article) :global(:is(h1, h2))`,
+    );
+  });
 });


### PR DESCRIPTION
Fixes #501

I ran into an issue where I could not use simple tailwind apply directives for dark mode and also couldn't import Daisy UI. I tracked it down to a problem with `svelte-preprocess` creating `:global` rules that svelte is not happy with. User https://github.com/MagDevX suggested an adjustment to `globalifySelector.js` `combinatorPattern` to prevent selectors with parenthesis from being split.