### PR TITLE
fix: remove customConditions tsconfig option

### DIFF
--- a/test/transformers/typescript.test.ts
+++ b/test/transformers/typescript.test.ts
@@ -12,7 +12,7 @@ import {
 import type { Processed } from '../../src/types';
 import type { Diagnostic } from 'typescript';
 
-spyConsole({ silent: true });
+spyConsole({ silent: false });
 
 const EXPECTED_SCRIPT = getFixtureContent('script.js');
 
@@ -202,6 +202,23 @@ describe('transformer - typescript', () => {
       expect(code).not.toContain('async function doIt');
       expect(code).not.toContain('&&=');
       expect(code).not.toContain('||=');
+    });
+
+    it('should remove customConditions option if necessary to prevent config error', async () => {
+      const opts = sveltePreprocess({
+        typescript: {
+          tsconfigFile: false,
+          compilerOptions: {
+            // we force a different module resolution in our transformer which
+            // would fail if we wouldn't also remove the customConditions
+            moduleResolution: 'NodeNext',
+            customConditions: ['development'],
+          },
+        },
+      });
+      const preprocessed = await preprocess(template, opts);
+
+      expect(preprocessed.toString?.()).toContain('export var hello');
     });
   });
 });


### PR DESCRIPTION
...in order to prevent invalid config errors which could arise from us forcing a module resolution. fixes #646

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to run `pnpm lint`!)

### Tests

- [x] Run the tests with `npm test` or `pnpm test`
