### PR TITLE
fix: update broken documentation example

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,7 +30,7 @@ import { sveltePreprocess } from 'svelte-preprocess';
  * @type {import('@sveltejs/kit').Config}
  */
 const config = {
-  preprocess: preprocess({
+  preprocess: sveltePreprocess({
     // ...svelte-preprocess options
   }),
   // ...other svelte options


### PR DESCRIPTION
Updates documentation example to correctly use changes from PR #641

PR #641 change the example to have `import { sveltePreprocess } from 'svelte-preprocess'` instead of `import preprocess from 'svelte-preprocess'`, but missed one spot where `preprocess` needed to change to `sveltePreprocess`.

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to run `pnpm lint`!)

### Tests

- [ ] Run the tests with `npm test` or `pnpm test`
