### PR TITLE
fix: ignore sass deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "postcss-load-config": "^3.1.4",
     "prettier": "^3.3.2",
     "pug": "^3.0.2",
-    "sass": "^1.56.2",
+    "sass": "^1.79.3",
     "stylus": "^0.55.0",
     "sugarss": "^4.0.0",
     "svelte": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^3.0.2
         version: 3.0.3
       sass:
-        specifier: ^1.56.2
-        version: 1.77.5
+        specifier: ^1.79.3
+        version: 1.79.3
       stylus:
         specifier: ^0.55.0
         version: 0.55.0
@@ -88,7 +88,7 @@ importers:
         version: 5.4.5
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@18.19.34)(less@3.13.1)(sass@1.77.5)(stylus@0.55.0)(sugarss@4.0.1(postcss@8.4.38))
+        version: 1.6.0(@types/node@18.19.34)(less@3.13.1)(sass@1.79.3)(stylus@0.55.0)(sugarss@4.0.1(postcss@8.4.38))
 
 packages:
 
@@ -1624,10 +1624,6 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  binary-extensions@2.3.0:
-    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
-    engines: {node: '>=8'}
-
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
@@ -1706,9 +1702,9 @@ packages:
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
-  chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
+  chokidar@4.0.1:
+    resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
+    engines: {node: '>= 14.16.0'}
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
@@ -2555,10 +2551,6 @@ packages:
 
   is-bigint@1.0.4:
     resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
-
-  is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
 
   is-boolean-object@1.1.2:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
@@ -3510,9 +3502,9 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
-  readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
+  readdirp@4.0.1:
+    resolution: {integrity: sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==}
+    engines: {node: '>= 14.16.0'}
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -3620,8 +3612,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sass@1.77.5:
-    resolution: {integrity: sha512-oDfX1mukIlxacPdQqNb6mV2tVCrnE+P3nVYioy72V5tlk56CPNcO4TCuFcaCRKKfJ1M3lH95CleRS+dVKL2qMg==}
+  sass@1.79.3:
+    resolution: {integrity: sha512-m7dZxh0W9EZ3cw50Me5GOuYm/tVAJAn91SUnohLRo9cXBixGUOdvmryN+dXpwR831bhoY3Zv7rEFt85PUwTmzA==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -5793,6 +5785,7 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+    optional: true
 
   argparse@1.0.10:
     dependencies:
@@ -6143,8 +6136,6 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  binary-extensions@2.3.0: {}
-
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
@@ -6237,17 +6228,9 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
-  chokidar@3.6.0:
+  chokidar@4.0.1:
     dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
+      readdirp: 4.0.1
 
   ci-info@3.9.0:
     optional: true
@@ -7309,10 +7292,6 @@ snapshots:
     dependencies:
       has-bigints: 1.0.2
 
-  is-binary-path@2.1.0:
-    dependencies:
-      binary-extensions: 2.3.0
-
   is-boolean-object@1.1.2:
     dependencies:
       call-bind: 1.0.7
@@ -8093,7 +8072,8 @@ snapshots:
       semver: 7.6.2
       validate-npm-package-license: 3.0.4
 
-  normalize-path@3.0.0: {}
+  normalize-path@3.0.0:
+    optional: true
 
   normalize-range@0.1.2: {}
 
@@ -8503,9 +8483,7 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
-  readdirp@3.6.0:
-    dependencies:
-      picomatch: 2.3.1
+  readdirp@4.0.1: {}
 
   redent@3.0.0:
     dependencies:
@@ -8639,9 +8617,9 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass@1.77.5:
+  sass@1.79.3:
     dependencies:
-      chokidar: 3.6.0
+      chokidar: 4.0.1
       immutable: 4.3.6
       source-map-js: 1.2.0
 
@@ -9083,13 +9061,13 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite-node@1.6.0(@types/node@18.19.34)(less@3.13.1)(sass@1.77.5)(stylus@0.55.0)(sugarss@4.0.1(postcss@8.4.38)):
+  vite-node@1.6.0(@types/node@18.19.34)(less@3.13.1)(sass@1.79.3)(stylus@0.55.0)(sugarss@4.0.1(postcss@8.4.38)):
     dependencies:
       cac: 6.7.14
       debug: 4.3.5
       pathe: 1.1.2
       picocolors: 1.0.1
-      vite: 5.2.13(@types/node@18.19.34)(less@3.13.1)(sass@1.77.5)(stylus@0.55.0)(sugarss@4.0.1(postcss@8.4.38))
+      vite: 5.2.13(@types/node@18.19.34)(less@3.13.1)(sass@1.79.3)(stylus@0.55.0)(sugarss@4.0.1(postcss@8.4.38))
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -9100,7 +9078,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.2.13(@types/node@18.19.34)(less@3.13.1)(sass@1.77.5)(stylus@0.55.0)(sugarss@4.0.1(postcss@8.4.38)):
+  vite@5.2.13(@types/node@18.19.34)(less@3.13.1)(sass@1.79.3)(stylus@0.55.0)(sugarss@4.0.1(postcss@8.4.38)):
     dependencies:
       esbuild: 0.20.2
       postcss: 8.4.38
@@ -9109,11 +9087,11 @@ snapshots:
       '@types/node': 18.19.34
       fsevents: 2.3.3
       less: 3.13.1
-      sass: 1.77.5
+      sass: 1.79.3
       stylus: 0.55.0
       sugarss: 4.0.1(postcss@8.4.38)
 
-  vitest@1.6.0(@types/node@18.19.34)(less@3.13.1)(sass@1.77.5)(stylus@0.55.0)(sugarss@4.0.1(postcss@8.4.38)):
+  vitest@1.6.0(@types/node@18.19.34)(less@3.13.1)(sass@1.79.3)(stylus@0.55.0)(sugarss@4.0.1(postcss@8.4.38)):
     dependencies:
       '@vitest/expect': 1.6.0
       '@vitest/runner': 1.6.0
@@ -9132,8 +9110,8 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.8.0
       tinypool: 0.8.4
-      vite: 5.2.13(@types/node@18.19.34)(less@3.13.1)(sass@1.77.5)(stylus@0.55.0)(sugarss@4.0.1(postcss@8.4.38))
-      vite-node: 1.6.0(@types/node@18.19.34)(less@3.13.1)(sass@1.77.5)(stylus@0.55.0)(sugarss@4.0.1(postcss@8.4.38))
+      vite: 5.2.13(@types/node@18.19.34)(less@3.13.1)(sass@1.79.3)(stylus@0.55.0)(sugarss@4.0.1(postcss@8.4.38))
+      vite-node: 1.6.0(@types/node@18.19.34)(less@3.13.1)(sass@1.79.3)(stylus@0.55.0)(sugarss@4.0.1(postcss@8.4.38))
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 18.19.34

--- a/src/transformers/scss.ts
+++ b/src/transformers/scss.ts
@@ -33,16 +33,24 @@ const tildeImporter: LegacySyncImporter = (url, prev) => {
   return { contents };
 };
 
+const infoRegex = /dart-sass\s(\d+)\.(\d+)\.(\d+)/;
+
 const transformer: Transformer<Options.Sass> = async ({
   content,
   filename,
   options = {},
 }) => {
-  const { renderSync } = await import('sass');
+  const { renderSync, info } = await import('sass');
 
   const { prependData, ...restOptions } = options;
+  const match = info.match(infoRegex) ?? [0, 0, 0, 0];
+  const [_, major, minor] = match.map(Number);
   const sassOptions: LegacyStringOptions<'sync'> = {
     ...restOptions,
+    silenceDeprecations:
+      major >= 1 && minor >= 79
+        ? ['legacy-js-api', ...(restOptions.silenceDeprecations || [])]
+        : undefined,
     includePaths: getIncludePaths(filename, options.includePaths),
     sourceMap: true,
     sourceMapEmbed: false,


### PR DESCRIPTION
Quick fix for now, in the mid term we should add proper support for the new API. @kaisermann if you remember what you did back then and how it translates to the new API, I would be grateful for a PR 😄 

fixes #656

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to run `pnpm lint`!)

### Tests

- [x] Run the tests with `npm test` or `pnpm test`
