### PR TITLE
fix: specify file extension when importing

### DIFF
--- a/.changeset/tame-facts-wave.md
+++ b/.changeset/tame-facts-wave.md
@@ -2,4 +2,4 @@
 'svelte-preprocess': patch
 ---
 
-fix: correctly import transformer during automatic processing
+fix: correctly import transformer when automatically processing with TypeScript 6

--- a/.changeset/tame-facts-wave.md
+++ b/.changeset/tame-facts-wave.md
@@ -1,0 +1,5 @@
+---
+'svelte-preprocess': patch
+---
+
+fix: correctly import transformer during automatic processing

--- a/src/autoProcess.ts
+++ b/src/autoProcess.ts
@@ -42,7 +42,9 @@ export const transform = async (
   }
 
   // todo: maybe add a try-catch here looking for module-not-found errors
-  const { transformer } = await import(/* @vite-ignore */ `./transformers/${name}.js`);
+  const { transformer } = await import(
+    /* @vite-ignore */ `./transformers/${name}.js`
+  );
 
   return transformer({
     content,

--- a/src/autoProcess.ts
+++ b/src/autoProcess.ts
@@ -42,7 +42,7 @@ export const transform = async (
   }
 
   // todo: maybe add a try-catch here looking for module-not-found errors
-  const { transformer } = await import(`./transformers/${name}.js`);
+  const { transformer } = await import(/* @vite-ignore */ `./transformers/${name}.js`);
 
   return transformer({
     content,

--- a/src/autoProcess.ts
+++ b/src/autoProcess.ts
@@ -42,7 +42,7 @@ export const transform = async (
   }
 
   // todo: maybe add a try-catch here looking for module-not-found errors
-  const { transformer } = await import(`./transformers/${name}`);
+  const { transformer } = await import(`./transformers/${name}.js`);
 
   return transformer({
     content,


### PR DESCRIPTION
There's one path I forgot to add a file extension to when doing the TypeScript 6 upgrade and that seems to cause the tests to fail in https://github.com/sveltejs/kit/pull/15896

### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [ ] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to run `pnpm lint`!)

### Tests

- [ ] Run the tests with `npm test` or `pnpm test`
